### PR TITLE
Add LinkedIn profile link

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslations, useLocale } from "next-intl";
 import { Mail } from "lucide-react";
-import { FaGithub } from "react-icons/fa";
-import { FaFacebook, FaInstagram, FaLine, FaWeixin, FaWhatsapp } from "react-icons/fa";
+import { FaGithub, FaLinkedin, FaFacebook, FaInstagram, FaLine, FaWeixin, FaWhatsapp } from "react-icons/fa";
 import { SiQiita, SiX, SiXiaohongshu } from "react-icons/si";
 import Image from "next/image";
 
@@ -51,6 +50,15 @@ const HeroSection = () => {
       icon: FaGithub,
       color: 'slate',
       priority: { ja: 7, en: 8, zh: 7 },
+      category: 'professional'
+    },
+    {
+      id: 'linkedin',
+      name: 'LinkedIn',
+      href: 'https://www.linkedin.com/in/ryoshin',
+      icon: FaLinkedin,
+      color: 'blue',
+      priority: { ja: 8, en: 9, zh: 8 },
       category: 'professional'
     },
     {


### PR DESCRIPTION
The `src/components/HeroSection.tsx` file was modified to integrate a LinkedIn profile link into the social media section.

*   The `FaLinkedin` icon was added to the existing import statement from `react-icons/fa`.
*   A new object for LinkedIn was appended to the `socialPlatforms` array. This entry includes:
    *   The URL `https://www.linkedin.com/in/ryoshin`.
    *   The `FaLinkedin` icon and a 'blue' color theme.
    *   Priority settings (`priority: { ja: 8, en: 9, zh: 8 }`) to control its display order across different languages.
    *   Categorization under 'professional'.

An initial import error was encountered due to the `react-icons` package not being installed, which was resolved by installing the dependency. The change ensures the LinkedIn profile is now accessible via the social links section, appearing within the 'Professional' category with defined display priorities.