### PR TITLE
Refine site styling toward Apple-like minimalism

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,35 +5,35 @@
 @variant dark (&:is(:root.dark *));
 
 :root {
-  --background: #fafafa;
-  --foreground: #0a0a0a;
-  --primary: #3b82f6;
-  --primary-dark: #1d4ed8;
-  --secondary: #8b5cf6;
-  --accent: #06b6d4;
-  --muted: #f1f5f9;
-  --border: #e2e8f0;
-  --gradient-start: #667eea;
-  --gradient-end: #764ba2;
+  --background: #f5f5f7;
+  --foreground: #1d1d1f;
+  --primary: #0071e3;
+  --primary-dark: #005bb5;
+  --secondary: #6e6e73;
+  --accent: #0a84ff;
+  --muted: #f2f2f2;
+  --border: #d2d2d7;
+  --gradient-start: #1d1d1f;
+  --gradient-end: #1d1d1f;
 }
 
 :root.dark {
-  --background: #020817;
-  --foreground: #f8fafc;
-  --primary: #3b82f6;
-  --primary-dark: #1d4ed8;
-  --secondary: #8b5cf6;
-  --accent: #06b6d4;
-  --muted: #1e293b;
-  --border: #334155;
-  --gradient-start: #667eea;
-  --gradient-end: #764ba2;
+  --background: #0b0b0f;
+  --foreground: #f5f5f7;
+  --primary: #0a84ff;
+  --primary-dark: #409cff;
+  --secondary: #a1a1a6;
+  --accent: #5ac8fa;
+  --muted: #1c1c1e;
+  --border: #2c2c2e;
+  --gradient-start: #f5f5f7;
+  --gradient-end: #f5f5f7;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'SF Pro Text', 'SF Pro Display', -apple-system, 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
 
@@ -93,45 +93,9 @@ body {
 }
 
 /* Glassmorphism utility classes */
-.glass {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.glass-dark {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-/* Gradient text utility */
+/* Gradient text utility (kept for legacy, neutralized) */
 .gradient-text {
-  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Modern shadow utilities */
-.shadow-glow {
-  box-shadow: 0 0 20px rgba(59, 130, 246, 0.15);
-}
-
-.shadow-glow-purple {
-  box-shadow: 0 0 20px rgba(139, 92, 246, 0.15);
-}
-
-/* Simplified animation utilities */
-@keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 15px rgba(59, 130, 246, 0.15); }
-  50% { box-shadow: 0 0 20px rgba(59, 130, 246, 0.25); }
-}
-
-.animate-pulse-glow {
-  animation: pulse-glow 3s ease-in-out infinite;
+  color: var(--foreground);
 }
 
 /* Container utility to ensure proper responsive behavior */

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -48,7 +48,7 @@ const AboutSection = () => {
   };
 
   return (
-    <section id="about" className="pt-32 pb-24 bg-gradient-to-b from-white to-slate-50/50 dark:from-slate-950 dark:to-slate-900/50 overflow-hidden" ref={ref}>
+    <section id="about" className="pt-32 pb-24 bg-white dark:bg-slate-950 overflow-hidden" ref={ref}>
       <div className="container mx-auto px-4 sm:px-6 max-w-7xl">
         {/* Header */}
         <motion.div
@@ -80,12 +80,11 @@ const AboutSection = () => {
           >
             <motion.div
               variants={itemVariants}
-              className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
+              className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-2xl p-6 sm:p-8 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 shadow-sm"
             >
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-blue-500/10 to-purple-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
               <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <University className="text-white" size={20} />
+                <div className="inline-flex p-2 sm:p-3 bg-slate-100 dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 mb-3 sm:mb-4">
+                  <University className="text-slate-700 dark:text-slate-200" size={20} />
                 </div>
                 <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
                   {t("education")}
@@ -101,12 +100,11 @@ const AboutSection = () => {
 
             <motion.div
               variants={itemVariants}
-              className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
+              className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-2xl p-6 sm:p-8 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 shadow-sm"
             >
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-purple-500/10 to-pink-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
               <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <Briefcase className="text-white" size={20} />
+                <div className="inline-flex p-2 sm:p-3 bg-slate-100 dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 mb-3 sm:mb-4">
+                  <Briefcase className="text-slate-700 dark:text-slate-200" size={20} />
                 </div>
                 <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
                   {t("experience")}
@@ -122,12 +120,11 @@ const AboutSection = () => {
 
             <motion.div
               variants={itemVariants}
-              className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
+              className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-2xl p-6 sm:p-8 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 shadow-sm"
             >
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-emerald-500/10 to-teal-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
               <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <Users className="text-white" size={20} />
+                <div className="inline-flex p-2 sm:p-3 bg-slate-100 dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 mb-3 sm:mb-4">
+                  <Users className="text-slate-700 dark:text-slate-200" size={20} />
                 </div>
                 <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
                   {t("teaching")}
@@ -159,9 +156,9 @@ const AboutSection = () => {
                   initial={{ opacity: 0, x: -20 }}
                   animate={inView ? { opacity: 1, x: 0 } : { opacity: 0, x: -20 }}
                   transition={{ delay: 0.3 + index * 0.1 }}
-                  className="group flex items-center gap-3 sm:gap-4 p-3 sm:p-4 bg-white dark:bg-slate-800/30 rounded-xl border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
+                  className="group flex items-center gap-3 sm:gap-4 p-3 sm:p-4 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 shadow-sm"
                 >
-                  <div className="flex-shrink-0 w-2 h-2 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full" />
+                  <div className="flex-shrink-0 w-2 h-2 bg-blue-500 rounded-full" />
                   <p className="text-slate-700 dark:text-slate-300 font-medium text-sm sm:text-base">
                     {field}
                   </p>

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -80,15 +80,15 @@ const GallerySection = () => {
 
 
   return (
-    <section id="gallery" className="pt-32 pb-24 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
+    <section id="gallery" className="pt-32 pb-24 bg-white dark:bg-slate-950">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 rounded-full text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 rounded-full text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <ImageIcon size={16} />
             {t("photoGallery")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-semibold text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
@@ -98,9 +98,9 @@ const GallerySection = () => {
 
         {/* Category Filter */}
         <div className="text-center mb-16">
-          <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
-            <div className="p-2 bg-gradient-to-r from-pink-500 to-rose-600 rounded-lg shadow-lg">
-              <Filter className="text-white" size={20} />
+          <div className="inline-flex items-center gap-3 px-6 py-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-full shadow-sm mb-8">
+            <div className="p-2 bg-slate-900 dark:bg-white rounded-lg shadow-sm">
+              <Filter className="text-white dark:text-slate-900" size={20} />
             </div>
             <span className="font-bold text-slate-800 dark:text-white">{t("categoryFilter")}</span>
           </div>
@@ -112,8 +112,8 @@ const GallerySection = () => {
                 onClick={() => setActiveCategory(category.key)}
                 className={`relative px-8 py-4 rounded-2xl font-semibold transition-all duration-200 ${
                   activeCategory === category.key
-                    ? "text-white shadow-xl bg-gradient-to-r from-blue-600 to-purple-600"
-                    : "bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 shadow-lg hover:shadow-xl"
+                    ? "text-white shadow-sm bg-blue-600"
+                    : "bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-slate-400 dark:hover:border-slate-600 shadow-sm hover:shadow-md"
                 }`}
               >
                 <span className="relative z-10">
@@ -135,7 +135,7 @@ const GallerySection = () => {
               className="group cursor-pointer transition-transform duration-200 hover:-translate-y-2"
               onClick={() => openModal(index)}
             >
-              <div className="relative aspect-square overflow-hidden rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-200 border-4 border-white dark:border-slate-800">
+              <div className="relative aspect-square overflow-hidden rounded-3xl shadow-sm hover:shadow-md transition-all duration-200 border border-slate-200 dark:border-slate-700">
                 <Image
                   src={image.src}
                   alt={image.alt}
@@ -148,7 +148,7 @@ const GallerySection = () => {
                 />
 
                 {/* Overlay */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-all duration-200" />
+                <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-all duration-200" />
                 
                 {/* Hover content */}
                 <div className="absolute inset-0 flex flex-col justify-end p-6 text-white opacity-0 group-hover:opacity-100 transition-all duration-200 transform translate-y-4 group-hover:translate-y-0">
@@ -161,7 +161,7 @@ const GallerySection = () => {
                 </div>
                 
                 {/* Floating camera icon */}
-                <div className="absolute top-4 right-4 p-3 bg-white/20 backdrop-blur-sm rounded-full opacity-0 group-hover:opacity-100 transition-all duration-200">
+                <div className="absolute top-4 right-4 p-3 bg-white/20 rounded-full opacity-0 group-hover:opacity-100 transition-all duration-200">
                   <Camera size={20} className="text-white" />
                 </div>
               </div>
@@ -173,13 +173,13 @@ const GallerySection = () => {
         <AnimatePresence>
           {selectedImage !== null && (
             <div
-              className="fixed inset-0 z-50 flex items-center justify-center bg-black/95 backdrop-blur-sm transition-opacity duration-200"
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/95 transition-opacity duration-200"
               onClick={closeModal}
             >
               <div className="relative max-w-6xl max-h-[90vh] mx-4">
                 {/* Modern close button */}
                 <button
-                  className="absolute -top-16 right-0 p-3 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-xl"
+                  className="absolute -top-16 right-0 p-3 bg-white/10 border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-sm"
                   onClick={closeModal}
                 >
                   <X size={24} />
@@ -189,7 +189,7 @@ const GallerySection = () => {
                 {filteredImages.length > 1 && (
                   <>
                     <button
-                      className="absolute left-6 top-1/2 -translate-y-1/2 p-4 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-xl"
+                      className="absolute left-6 top-1/2 -translate-y-1/2 p-4 bg-white/10 border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-sm"
                       onClick={(e) => {
                         e.stopPropagation();
                         prevImage();
@@ -198,7 +198,7 @@ const GallerySection = () => {
                       <ChevronLeft size={28} />
                     </button>
                     <button
-                      className="absolute right-6 top-1/2 -translate-y-1/2 p-4 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-xl"
+                      className="absolute right-6 top-1/2 -translate-y-1/2 p-4 bg-white/10 border border-white/20 rounded-full text-white hover:bg-white/20 transition-all duration-200 shadow-sm"
                       onClick={(e) => {
                         e.stopPropagation();
                         nextImage();
@@ -211,7 +211,7 @@ const GallerySection = () => {
 
                 {/* Image container */}
                 <div
-                  className="relative bg-white/5 backdrop-blur-sm border border-white/10 rounded-3xl overflow-hidden shadow-2xl"
+                  className="relative bg-white/5 border border-white/10 rounded-3xl overflow-hidden shadow-xl"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <Image
@@ -223,7 +223,7 @@ const GallerySection = () => {
                   />
 
                   {/* Modern image info overlay */}
-                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/90 via-black/60 to-transparent p-8 backdrop-blur-sm">
+                  <div className="absolute bottom-0 left-0 right-0 bg-black/70 p-8">
                     <h3 className="text-white text-2xl font-bold mb-3">
                       {t(filteredImages[selectedImage].titleKey)}
                     </h3>
@@ -235,7 +235,7 @@ const GallerySection = () => {
 
                 {/* Modern image counter */}
                 {filteredImages.length > 1 && (
-                  <div className="absolute -bottom-16 left-1/2 -translate-x-1/2 px-4 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white text-sm font-medium shadow-xl">
+                  <div className="absolute -bottom-16 left-1/2 -translate-x-1/2 px-4 py-2 bg-white/10 border border-white/20 rounded-full text-white text-sm font-medium shadow-sm">
                     {selectedImage + 1} {tCommon("of")} {filteredImages.length}
                   </div>
                 )}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -177,22 +177,14 @@ const HeroSection = () => {
   }, []);
 
   return (
-    <section id="hero" className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      {/* Modern gradient background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50/50 to-purple-50/30 dark:from-slate-950 dark:via-blue-950/20 dark:to-purple-950/10" />
-      
-      {/* Minimal background elements */}
-      <div className="absolute inset-0 opacity-20 dark:opacity-10">
-        <div className="absolute top-20 right-20 w-64 h-64 bg-blue-400/10 rounded-full blur-2xl" />
-        <div className="absolute bottom-20 left-20 w-80 h-80 bg-purple-400/10 rounded-full blur-2xl" />
-      </div>
+    <section id="hero" className="relative min-h-screen flex items-center justify-center overflow-hidden bg-white dark:bg-slate-950">
 
       <div className="container mx-auto px-4 sm:px-6 relative z-10 w-full max-w-7xl">
         <div className="text-center max-w-5xl mx-auto pt-32 pb-16">
 
           {/* Name */}
           <div className="mb-12">
-            <h1 className="text-3xl sm:text-5xl md:text-7xl lg:text-8xl font-black gradient-text mb-4 tracking-tight px-4">
+            <h1 className="text-3xl sm:text-5xl md:text-7xl lg:text-8xl font-semibold text-slate-900 dark:text-white mb-4 tracking-tight px-4">
               {names[currentNameIndex]}
             </h1>
           </div>
@@ -200,13 +192,13 @@ const HeroSection = () => {
           {/* Role */}
           <div className="mb-12 px-4">
             <div className="flex items-center justify-center gap-4 sm:gap-8 mb-6">
-              <div className="h-px bg-gradient-to-r from-transparent via-blue-500/50 to-transparent flex-1 max-w-16 sm:max-w-32" />
-              <div className="relative px-4 sm:px-8 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-full border border-blue-200/50 dark:border-blue-700/50">
-                <span className="text-sm sm:text-xl md:text-2xl font-bold text-blue-600 dark:text-blue-400">
+              <div className="h-px bg-slate-200 dark:bg-slate-800 flex-1 max-w-16 sm:max-w-32" />
+              <div className="relative px-4 sm:px-8 py-3 bg-white dark:bg-slate-900 rounded-full border border-slate-200 dark:border-slate-700">
+                <span className="text-sm sm:text-xl md:text-2xl font-semibold text-slate-700 dark:text-slate-200">
                   {roles[currentRoleIndex]}
                 </span>
               </div>
-              <div className="h-px bg-gradient-to-r from-transparent via-blue-500/50 to-transparent flex-1 max-w-16 sm:max-w-32" />
+              <div className="h-px bg-slate-200 dark:bg-slate-800 flex-1 max-w-16 sm:max-w-32" />
             </div>
           </div>
 
@@ -222,11 +214,11 @@ const HeroSection = () => {
 
           {/* Personal Details */}
           <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4 mb-8 text-xs sm:text-sm md:text-base text-slate-600 dark:text-slate-400 px-4">
-            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm rounded-full border border-slate-200/30 dark:border-slate-700/30">
+            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white dark:bg-slate-900 rounded-full border border-slate-200 dark:border-slate-700">
               <span className="font-semibold">{t("origin")}</span>
               <span className="text-slate-700 dark:text-slate-300">{t("beijing")}</span>
             </div>
-            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm rounded-full border border-slate-200/30 dark:border-slate-700/30">
+            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white dark:bg-slate-900 rounded-full border border-slate-200 dark:border-slate-700">
               <span className="font-semibold">{t("current")}</span>
               <span className="text-slate-700 dark:text-slate-300">{t("kyoto")}</span>
             </div>
@@ -236,7 +228,7 @@ const HeroSection = () => {
           <div className="mt-12 mb-20 px-4">
             <div className="flex flex-col items-center justify-center">
               {/* Elegant divider */}
-              <div className="w-24 h-px bg-gradient-to-r from-transparent via-slate-400 dark:via-slate-600 to-transparent mb-10" />
+              <div className="w-24 h-px bg-slate-200 dark:bg-slate-700 mb-10" />
               
               {/* Social Links - Clean Layout */}
               <div className="flex flex-wrap justify-center items-start gap-6 sm:gap-10 max-w-4xl mx-auto">
@@ -301,12 +293,12 @@ const HeroSection = () => {
                           
                           // Define color classes
                           const colorClasses = {
-                            slate: 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700',
-                            sky: 'bg-sky-50 dark:bg-sky-950 text-sky-700 dark:text-sky-300 border-sky-200 dark:border-sky-800',
-                            green: 'bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800',
-                            blue: 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800',
-                            pink: 'bg-pink-50 dark:bg-pink-950 text-pink-700 dark:text-pink-300 border-pink-200 dark:border-pink-800',
-                            red: 'bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800'
+                            slate: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+                            sky: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+                            green: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+                            blue: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+                            pink: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+                            red: 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700'
                           };
                           
                           if (isQRPlatform) {
@@ -317,28 +309,20 @@ const HeroSection = () => {
                               >
                                 <button
                                   onClick={() => platform.id === 'wechat' ? setShowWeChatQR(!showWeChatQR) : setShowWhatsAppQR(!showWhatsAppQR)}
-                                  className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:scale-105`}
+                                  className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:border-slate-400 dark:hover:border-slate-500`}
                                 >
-                                  <div
-                                    className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                                    style={{
-                                      background: platform.color === 'green' 
-                                        ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)' 
-                                        : 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)'
-                                    }}
-                                  />
-                                  {platform.icon && <platform.icon size={16} className="sm:w-6 sm:h-6 relative z-10 group-hover:text-white transition-colors duration-300" />}
+                                  {platform.icon && <platform.icon size={16} className="sm:w-6 sm:h-6 relative z-10 group-hover:text-slate-900 dark:group-hover:text-white transition-colors duration-200" />}
                                 </button>
                                 {((platform.id === 'wechat' && showWeChatQR) || (platform.id === 'whatsapp' && showWhatsAppQR)) && (
                                   <>
                                     {/* Backdrop */}
                                     <div
-                                      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+                                      className="fixed inset-0 bg-black/60 z-40"
                                       onClick={() => platform.id === 'wechat' ? setShowWeChatQR(false) : setShowWhatsAppQR(false)}
                                     />
                                     {/* Modal */}
                                     <div
-                                      className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-4 sm:p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-2xl z-50 max-w-sm mx-4"
+                                      className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-4 sm:p-8 bg-white dark:bg-slate-900 rounded-2xl shadow-2xl z-50 max-w-sm mx-4 border border-slate-200 dark:border-slate-700"
                                     >
                                       <h3 className="text-lg sm:text-xl font-semibold text-slate-800 dark:text-slate-200 mb-4 sm:mb-6 text-center">
                                         {platform.id === 'wechat' ? tSocialActions('wechatQR') : tSocialActions('whatsappQR')}
@@ -371,21 +355,10 @@ const HeroSection = () => {
                               href={platform.href}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:scale-105`}
+                              className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:border-slate-400 dark:hover:border-slate-500`}
                             >
-                              <div
-                                className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                                style={{
-                                  background: platform.color === 'slate' ? 'linear-gradient(135deg, #475569 0%, #1e293b 100%)' 
-                                    : platform.color === 'green' ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)' 
-                                    : platform.color === 'blue' ? 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)' 
-                                    : platform.color === 'pink' ? 'linear-gradient(135deg, #ec4899 0%, #a855f7 100%)' 
-                                    : platform.color === 'red' ? 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)'
-                                    : 'linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%)'
-                                }}
-                              />
                               {platform.icon ? (
-                                <platform.icon size={18} className="sm:w-5 sm:h-5 relative z-10 group-hover:text-white transition-colors duration-200" />
+                                <platform.icon size={18} className="sm:w-5 sm:h-5 relative z-10 group-hover:text-slate-900 dark:group-hover:text-white transition-colors duration-200" />
                               ) : (
                                 <Image 
                                   src={platform.iconPath!} 

--- a/src/components/LatestZennArticle.tsx
+++ b/src/components/LatestZennArticle.tsx
@@ -100,9 +100,6 @@ export default function LatestZennArticle() {
 
   return (
     <section className={`relative overflow-hidden transition-all duration-700 ${visible ? 'opacity-100' : 'opacity-0'} -mt-8`}>
-      {/* Dynamic background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-green-500/3 to-transparent dark:via-green-400/3" />
-      
       <div className="container mx-auto px-4">
         <div className="max-w-5xl mx-auto space-y-1">
           {articles.map((article, index) => (
@@ -123,25 +120,17 @@ export default function LatestZennArticle() {
                   transitionDelay: `${index * 100}ms`
                 }}
               >
-                {/* Animated line effect */}
-                <div className={`absolute left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-green-500/30 to-transparent transition-all duration-700 ${hoveredIndex === index ? 'scale-x-100 opacity-100' : 'scale-x-0 opacity-0'}`} />
-                
-                <div className="relative flex items-center gap-3 py-2 px-2 group">
+                <div className="relative flex items-center gap-3 py-2 px-2 group rounded-lg transition-colors duration-200 hover:bg-slate-50 dark:hover:bg-slate-900">
                   {/* Animated sparkle icon - only on first item */}
                   {index === 0 && (
                     <div className="relative flex-shrink-0">
-                      <RiSparklingFill className={`w-4 h-4 text-green-500 dark:text-green-400 transition-all duration-500 ${hoveredIndex === 0 ? 'scale-125 rotate-12' : ''}`} />
-                      {visible && (
-                        <div className="absolute inset-0 animate-ping">
-                          <RiSparklingFill className="w-4 h-4 text-green-500/40 dark:text-green-400/40" />
-                        </div>
-                      )}
+                      <RiSparklingFill className={`w-4 h-4 text-blue-500 dark:text-blue-400 transition-all duration-500 ${hoveredIndex === 0 ? 'scale-110' : ''}`} />
                     </div>
                   )}
                   
                   {/* Index number for items 2 and 3 */}
                   {index > 0 && (
-                    <span className={`flex-shrink-0 w-4 h-4 text-xs font-medium text-slate-400 dark:text-slate-500 transition-all duration-300 ${hoveredIndex === index ? 'text-green-500 dark:text-green-400' : ''}`}>
+                    <span className={`flex-shrink-0 w-4 h-4 text-xs font-medium text-slate-400 dark:text-slate-500 transition-all duration-300 ${hoveredIndex === index ? 'text-blue-600 dark:text-blue-400' : ''}`}>
                       {index + 1}.
                     </span>
                   )}
@@ -151,8 +140,8 @@ export default function LatestZennArticle() {
                     {/* Date badge */}
                     <span className={`flex-shrink-0 text-xs px-2 py-0.5 rounded-full transition-all duration-300 ${
                       index === 0 
-                        ? `bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 ${hoveredIndex === 0 ? 'bg-green-200 dark:bg-green-800/40' : ''}`
-                        : `bg-slate-100 dark:bg-slate-800/30 text-slate-600 dark:text-slate-400 ${hoveredIndex === index ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400' : ''}`
+                        ? `bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 ${hoveredIndex === 0 ? 'bg-blue-100 dark:bg-blue-900/50' : ''}`
+                        : `bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 ${hoveredIndex === index ? 'bg-slate-200 dark:bg-slate-700' : ''}`
                     }`}>
                       {formatDate(article.pubDate)}
                     </span>
@@ -160,8 +149,8 @@ export default function LatestZennArticle() {
                     {/* Title with overflow handling */}
                     <h3 className={`flex-1 text-sm font-medium truncate transition-all duration-300 ${
                       index === 0
-                        ? `text-slate-700 dark:text-slate-300 ${hoveredIndex === 0 ? 'text-green-600 dark:text-green-400' : ''}`
-                        : `text-slate-600 dark:text-slate-400 ${hoveredIndex === index ? 'text-green-600 dark:text-green-400' : ''}`
+                        ? `text-slate-800 dark:text-slate-200 ${hoveredIndex === 0 ? 'text-slate-900 dark:text-white' : ''}`
+                        : `text-slate-600 dark:text-slate-400 ${hoveredIndex === index ? 'text-slate-800 dark:text-slate-200' : ''}`
                     }`}>
                       {article.title}
                     </h3>
@@ -169,14 +158,11 @@ export default function LatestZennArticle() {
                     {/* Arrow icon with animation */}
                     <RiArrowRightUpLine className={`flex-shrink-0 w-4 h-4 transition-all duration-300 ${
                       hoveredIndex === index 
-                        ? 'text-green-500 dark:text-green-400 translate-x-1 -translate-y-1' 
+                        ? 'text-blue-600 dark:text-blue-400 translate-x-1 -translate-y-1' 
                         : 'text-slate-400 dark:text-slate-500 opacity-60'
                     }`} />
                   </div>
                 </div>
-
-                {/* Bottom animated line */}
-                <div className={`absolute left-0 right-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-green-500/30 to-transparent transition-all duration-700 ${hoveredIndex === index ? 'scale-x-100 opacity-100' : 'scale-x-0 opacity-0'}`} />
               </div>
             </Link>
           ))}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -125,7 +125,7 @@ const Navigation = () => {
       <motion.nav
         className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
           isScrolled
-            ? "bg-white/95 dark:bg-slate-950/95 backdrop-blur-md shadow-lg border-b border-slate-200/20 dark:border-slate-800/20"
+            ? "bg-white/95 dark:bg-slate-950/95 shadow-sm border-b border-slate-200 dark:border-slate-800"
             : "bg-transparent"
         }`}
         initial={{ y: -100 }}
@@ -142,17 +142,16 @@ const Navigation = () => {
             transition={{ type: "spring", stiffness: 400, damping: 17 }}
           >
             <div className="relative w-[28px] h-[28px] sm:w-[36px] sm:h-[36px]">
-              <div className="absolute inset-1 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full blur-md opacity-70" />
               <Image
                 src="/logo.svg"
                 alt="Logo"
                 width={24}
                 height={24}
-                className="relative rounded-full border-2 border-white dark:border-slate-800 shadow-lg sm:w-8 sm:h-8"
+                className="relative rounded-full border border-slate-200 dark:border-slate-800 shadow-sm sm:w-8 sm:h-8 bg-white dark:bg-slate-900"
               />
             </div>
             <div className="hidden sm:block">
-              <h1 className="text-base sm:text-xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">
+              <h1 className="text-base sm:text-xl font-semibold text-slate-900 dark:text-white">
                 {namesT("shortName")}
               </h1>
               <p className="text-xs sm:text-sm text-slate-600 dark:text-slate-400 font-medium">
@@ -173,7 +172,7 @@ const Navigation = () => {
               >
                 {activeSection === item.sectionId && (
                   <motion.div
-                    className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full"
+                    className="absolute inset-0 bg-blue-600 rounded-full"
                     layoutId="activeNavItem"
                     transition={{ type: "spring", stiffness: 380, damping: 30 }}
                   />
@@ -196,7 +195,7 @@ const Navigation = () => {
               onClick={() => setShowMoreMenu(!showMoreMenu)}
               className={`p-2 lg:p-3 rounded-full transition-all duration-300 ${
                 secondaryNavItems.some(item => activeSection === item.sectionId)
-                  ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white"
+                  ? "bg-blue-600 text-white"
                   : "text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-slate-100 dark:hover:bg-slate-800"
               }`}
               whileHover={{ scale: 1.05 }}
@@ -211,7 +210,7 @@ const Navigation = () => {
             {/* Theme Toggle */}
             <motion.button
               onClick={toggleTheme}
-              className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+              className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500 transition-all duration-300 shadow-sm hover:shadow-md"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               aria-label="Toggle dark mode"
@@ -249,7 +248,7 @@ const Navigation = () => {
             <div className="relative language-menu">
               <motion.button
                 onClick={() => setShowLangMenu(!showLangMenu)}
-                className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+                className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500 transition-all duration-300 shadow-sm hover:shadow-md"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -264,7 +263,7 @@ const Navigation = () => {
               <AnimatePresence>
                 {showLangMenu && (
                   <motion.div
-                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
+                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-700"
                     initial={{ opacity: 0, y: -10, scale: 0.95 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
                     exit={{ opacity: 0, y: -10, scale: 0.95 }}
@@ -276,8 +275,8 @@ const Navigation = () => {
                         onClick={() => handleLanguageChange(language.code)}
                         className={`w-full text-left px-3 lg:px-4 py-2 lg:py-3 text-xs lg:text-sm font-medium transition-all duration-200 ${
                           locale === language.code
-                            ? "bg-blue-50 dark:bg-blue-950/50 text-blue-600 dark:text-blue-400"
-                            : "text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50"
+                            ? "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100"
+                            : "text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
                         }`}
                         whileHover={{ x: 4 }}
                       >
@@ -295,7 +294,7 @@ const Navigation = () => {
             {/* Mobile Menu Button */}
             <motion.button
               onClick={() => setShowMoreMenu(!showMoreMenu)}
-              className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+              className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500 transition-all duration-300 shadow-sm hover:shadow-md"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
@@ -330,7 +329,7 @@ const Navigation = () => {
             <div className="absolute top-6 right-6 z-[100001]">
               <motion.button
                 onClick={() => setShowMoreMenu(false)}
-                className="p-3 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all duration-300 shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
+                className="p-3 rounded-full bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-all duration-300 shadow-sm border border-slate-200 dark:border-slate-700"
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
               >
@@ -355,7 +354,7 @@ const Navigation = () => {
                         onClick={() => navigateTo(item.sectionId)}
                         className={`block w-full text-center px-4 sm:px-6 py-3 sm:py-4 rounded-xl font-semibold text-base sm:text-lg transition-all duration-300 ${
                           activeSection === item.sectionId
-                            ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg"
+                            ? "bg-blue-600 text-white shadow-md"
                             : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700"
                         }`}
                         whileHover={{ scale: 1.05 }}
@@ -374,7 +373,7 @@ const Navigation = () => {
                 <div className="hidden lg:block">
                   {/* Menu Title */}
                   <motion.h2
-                    className="text-3xl sm:text-4xl md:text-6xl font-black gradient-text mb-12 sm:mb-16"
+                    className="text-3xl sm:text-4xl md:text-6xl font-semibold text-slate-900 dark:text-white mb-12 sm:mb-16"
                     initial={{ y: 30, opacity: 0 }}
                     animate={{ y: 0, opacity: 1 }}
                     transition={{ delay: 0.2, duration: 0.4 }}
@@ -393,8 +392,8 @@ const Navigation = () => {
                         }}
                         className={`p-4 sm:p-6 rounded-2xl text-lg sm:text-xl font-semibold transition-all duration-300 ${
                           activeSection === item.sectionId
-                            ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-xl"
-                            : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-blue-50 dark:hover:bg-slate-700 border border-slate-200/50 dark:border-slate-700/50"
+                            ? "bg-blue-600 text-white shadow-md"
+                            : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-700"
                         }`}
                         whileHover={{ scale: 1.05, y: -5 }}
                         whileTap={{ scale: 0.95 }}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -91,51 +91,13 @@ const ProjectsSection = () => {
   });
 
 
-  const getColorClasses = (color: string) => {
-    switch (color) {
-      case "blue":
-        return {
-          bg: "bg-blue-50 dark:bg-blue-900/20",
-          border: "border-blue-200 dark:border-blue-800",
-          accent: "bg-blue-600",
-          text: "text-blue-600 dark:text-blue-400",
-        };
-      case "green":
-        return {
-          bg: "bg-green-50 dark:bg-green-900/20",
-          border: "border-green-200 dark:border-green-800",
-          accent: "bg-green-600",
-          text: "text-green-600 dark:text-green-400",
-        };
-      case "purple":
-        return {
-          bg: "bg-purple-50 dark:bg-purple-900/20",
-          border: "border-purple-200 dark:border-purple-800",
-          accent: "bg-purple-600",
-          text: "text-purple-600 dark:text-purple-400",
-        };
-      case "red":
-        return {
-          bg: "bg-red-50 dark:bg-red-900/20",
-          border: "border-red-200 dark:border-red-800",
-          accent: "bg-red-600",
-          text: "text-red-600 dark:text-red-400",
-        };
-      case "orange":
-        return {
-          bg: "bg-orange-50 dark:bg-orange-900/20",
-          border: "border-orange-200 dark:border-orange-800",
-          accent: "bg-orange-600",
-          text: "text-orange-600 dark:text-orange-400",
-        };
-      default:
-        return {
-          bg: "bg-gray-50 dark:bg-gray-900/20",
-          border: "border-gray-200 dark:border-gray-800",
-          accent: "bg-gray-600",
-          text: "text-gray-600 dark:text-gray-400",
-        };
-    }
+  const getColorClasses = (_color: string) => {
+    return {
+      bg: "bg-slate-50 dark:bg-slate-900",
+      border: "border-slate-200 dark:border-slate-700",
+      accent: "bg-blue-600",
+      text: "text-blue-600 dark:text-blue-400",
+    };
   };
 
   const getStatusBadge = (status: string) => {
@@ -144,39 +106,39 @@ const ProjectsSection = () => {
         return {
           label: tStatus("completed"),
           color:
-            "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400",
+            "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200",
         };
       case "active":
         return {
           label: tStatus("active"),
           color:
-            "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400",
+            "bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300",
         };
       case "ongoing":
         return {
           label: tStatus("ongoing"),
           color:
-            "bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400",
+            "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200",
         };
       default:
         return {
           label: tStatus("undefined"),
           color:
-            "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400",
+            "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200",
         };
     }
   };
 
   return (
-    <section id="projects" className="pt-32 pb-24 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50">
+    <section id="projects" className="pt-32 pb-24 bg-slate-50 dark:bg-slate-950">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 rounded-full text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <Rocket size={16} />
             {tBadges("featuredProjects")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-semibold text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
@@ -186,9 +148,9 @@ const ProjectsSection = () => {
 
         {/* Leadership Section */}
         <div className="mb-16">
-          <div className="max-w-4xl mx-auto bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl">
+          <div className="max-w-4xl mx-auto bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-200 dark:border-slate-700 shadow-sm">
             <div className="flex items-start gap-6">
-              <div className="p-4 rounded-2xl bg-green-600 text-white shadow-lg">
+              <div className="p-4 rounded-2xl bg-blue-600 text-white shadow-sm">
                 <Users size={32} />
               </div>
               <div className="flex-1">
@@ -202,7 +164,7 @@ const ProjectsSection = () => {
                   {leadership.skills.map((skill, skillIndex) => (
                     <span
                       key={skillIndex}
-                      className="px-4 py-2 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded-full text-sm font-semibold border border-green-200 dark:border-green-800"
+                      className="px-4 py-2 bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 rounded-full text-sm font-semibold border border-slate-200 dark:border-slate-700"
                     >
                       {skill}
                     </span>
@@ -223,24 +185,21 @@ const ProjectsSection = () => {
             return (
               <div
                 key={index}
-                className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200"
               >
-                {/* Background gradient overlay */}
-                <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                
                 <div className="relative z-10">
                   {/* Header */}
                   <div className="flex items-start justify-between mb-6">
                     <div className="flex items-start gap-4">
-                      <div className={`p-4 rounded-2xl ${colors.accent} text-white shadow-lg transition-transform duration-200`}>
+                      <div className={`p-4 rounded-2xl ${colors.accent} text-white shadow-sm transition-transform duration-200`}>
                         <IconComponent size={28} />
                       </div>
                       <div>
-                        <h3 className="text-2xl font-bold text-slate-800 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
+                        <h3 className="text-2xl font-bold text-slate-900 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
                           {project.title}
                         </h3>
                         <div className="flex items-center gap-3">
-                          <span className={`px-3 py-1 rounded-full text-sm font-bold ${statusBadge.color} shadow-md transition-transform duration-200`}>
+                          <span className={`px-3 py-1 rounded-full text-sm font-semibold ${statusBadge.color} transition-transform duration-200`}>
                             {statusBadge.label}
                           </span>
                           <span className="text-sm text-slate-500 dark:text-slate-400 font-medium flex items-center gap-1">
@@ -259,7 +218,7 @@ const ProjectsSection = () => {
                             href={project.links.live}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="p-3 bg-white/80 dark:bg-slate-700/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-600/50 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 text-blue-600 dark:text-blue-400"
+                            className="p-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm hover:shadow-md transition-all duration-200 text-blue-600 dark:text-blue-400"
                           >
                             <ExternalLink size={20} />
                           </a>
@@ -285,7 +244,7 @@ const ProjectsSection = () => {
                           key={featureIndex}
                           className="text-slate-600 dark:text-slate-400 flex items-start gap-3"
                         >
-                          <div className={`w-3 h-3 ${colors.accent} rounded-full mt-1.5 flex-shrink-0 shadow-md`} />
+                          <div className={`w-3 h-3 ${colors.accent} rounded-full mt-1.5 flex-shrink-0`} />
                           <span className="font-medium">{feature}</span>
                         </li>
                       ))}
@@ -295,7 +254,7 @@ const ProjectsSection = () => {
                   {/* Technologies */}
                   <div>
                     <h4 className="text-lg font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
-                      <div className="w-2 h-2 bg-purple-500 rounded-full" />
+                      <div className="w-2 h-2 bg-blue-500 rounded-full" />
                       {t("techStack")}
                     </h4>
                     <div className="flex flex-wrap gap-3">
@@ -304,7 +263,7 @@ const ProjectsSection = () => {
                         return (
                           <div
                             key={techIndex}
-                            className="flex items-center gap-2 px-4 py-2 bg-white/80 dark:bg-slate-700/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-600/50 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"
+                            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm hover:shadow-md transition-all duration-200"
                           >
                             <TechIcon size={18} />
                             <span className="text-sm text-slate-700 dark:text-slate-300 font-semibold">

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -101,15 +101,15 @@ const ResearchSection = () => {
   };
 
   return (
-    <section id="research" className="pt-32 pb-24 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50" ref={ref}>
+    <section id="research" className="pt-32 pb-24 bg-slate-50 dark:bg-slate-950" ref={ref}>
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 rounded-full text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 rounded-full text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <Microscope size={16} />
             {t("academicResearch")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-semibold text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
@@ -139,7 +139,7 @@ const ResearchSection = () => {
               <motion.div
                 key={index}
                 variants={itemVariants}
-                className="bg-white dark:bg-slate-800 rounded-lg p-6 shadow-lg hover:shadow-xl transition-shadow"
+                className="bg-white dark:bg-slate-900 rounded-lg p-6 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-shadow"
               >
                 <div className="flex items-start justify-between flex-wrap gap-2">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex-1">
@@ -148,12 +148,12 @@ const ResearchSection = () => {
                   <div className="flex items-center gap-2">
                     <span className={`text-sm font-medium px-3 py-1 rounded-full ${
                       pub.type === "journal" 
-                        ? "text-purple-600 dark:text-purple-400 bg-purple-100 dark:bg-purple-900/30"
-                        : "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30"
+                        ? "text-blue-600 dark:text-blue-300 bg-blue-50 dark:bg-blue-950/40"
+                        : "text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800"
                     }`}>
                       {pub.year}
                     </span>
-                    <span className="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded">
+                    <span className="text-xs px-2 py-1 bg-slate-100 dark:bg-slate-800 rounded">
                       {pub.type === "journal" ? t("peerReviewedPapers") : t("conferencePresentations")}
                     </span>
                   </div>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -160,15 +160,15 @@ const SkillsSection = () => {
   };
 
   return (
-    <section id="skills" className="pt-32 pb-24 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
+    <section id="skills" className="pt-32 pb-24 bg-white dark:bg-slate-950">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 rounded-full text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <Zap size={16} />
             {t("technicalExpertise")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-semibold text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
@@ -185,17 +185,14 @@ const SkillsSection = () => {
               return (
                 <div
                   key={categoryIndex}
-                  className="group relative overflow-hidden bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200"
                 >
-                  {/* Background gradient */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                  
                   <div className="relative z-10">
                     <div className="flex items-center mb-8">
                       <div className={`p-4 rounded-2xl ${getColorClasses(category.color)} text-white mr-4 shadow-lg transition-transform duration-200`}>
                         <IconComponent size={28} />
                       </div>
-                      <h3 className="text-2xl font-bold text-slate-800 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
+                      <h3 className="text-2xl font-bold text-slate-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
                         {t(category.titleKey)}
                       </h3>
                     </div>
@@ -211,7 +208,7 @@ const SkillsSection = () => {
                           >
                             <div className="flex items-center justify-between">
                               <div className="flex items-center gap-4">
-                                <div className="p-2 bg-white dark:bg-slate-700 rounded-xl shadow-md">
+                                <div className="p-2 bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm">
                                   <SkillIcon
                                     size={24}
                                     style={{ color: skill.color }}
@@ -230,11 +227,10 @@ const SkillsSection = () => {
                               <div
                                 className="h-full rounded-full relative overflow-hidden transition-all duration-1000 ease-out"
                                 style={{ 
-                                  background: `linear-gradient(90deg, ${skill.color}99, ${skill.color})`,
+                                  background: skill.color,
                                   width: `${skill.level}%`
                                 }}
                               >
-                                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent" />
                               </div>
                             </div>
                           </div>
@@ -251,9 +247,9 @@ const SkillsSection = () => {
         {/* Certifications */}
         <div className="mb-24">
           <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
-              <div className="p-2 bg-gradient-to-r from-amber-500 to-orange-600 rounded-lg shadow-lg">
-                <Award className="text-white" size={20} />
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-full shadow-sm mb-8">
+              <div className="p-2 bg-slate-900 dark:bg-white rounded-lg shadow-sm">
+                <Award className="text-white dark:text-slate-900" size={20} />
               </div>
               <span className="font-bold text-slate-800 dark:text-white">{certifications.title}</span>
             </div>
@@ -267,20 +263,20 @@ const SkillsSection = () => {
               {certifications.list.map((cert, index) => (
                 <div
                   key={index}
-                  className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl p-6 border border-slate-200/50 dark:border-slate-700/50 shadow-lg hover:shadow-xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-2xl p-6 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200"
                 >
                   
                   <div className="relative z-10">
                     <div className="flex items-start justify-between mb-4">
-                      <div className="p-3 bg-gradient-to-r from-amber-500/20 to-orange-600/20 rounded-xl">
-                        <Award className="text-amber-600 dark:text-amber-400" size={24} />
+                      <div className="p-3 bg-slate-100 dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700">
+                        <Award className="text-slate-700 dark:text-slate-200" size={24} />
                       </div>
-                      <span className="text-sm font-medium text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-3 py-1 rounded-full">
+                      <span className="text-sm font-medium text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-3 py-1 rounded-full">
                         {cert.date}
                       </span>
                     </div>
                     
-                    <h4 className="text-lg font-bold text-slate-800 dark:text-white mb-3 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors duration-200">
+                    <h4 className="text-lg font-bold text-slate-900 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
                       {cert.name}
                     </h4>
                     
@@ -297,9 +293,9 @@ const SkillsSection = () => {
         {/* Language Skills */}
         <div>
           <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
-              <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-600 rounded-lg shadow-lg">
-                <Globe className="text-white" size={20} />
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-full shadow-sm mb-8">
+              <div className="p-2 bg-slate-900 dark:bg-white rounded-lg shadow-sm">
+                <Globe className="text-white dark:text-slate-900" size={20} />
               </div>
               <span className="font-bold text-slate-800 dark:text-white">{t("languages")}</span>
             </div>
@@ -310,17 +306,14 @@ const SkillsSection = () => {
               {languages.map((language, index) => (
                 <div
                   key={index}
-                  className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-900 rounded-3xl p-8 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200"
                 >
-                  {/* Background gradient */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-emerald-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-emerald-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                  
                   <div className="relative z-10 text-center">
                     <div className="text-6xl mb-6 filter drop-shadow-lg">
                       {language.flag}
                     </div>
                     
-                    <h4 className="text-2xl font-bold text-slate-800 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
+                    <h4 className="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
                       {language.name}
                     </h4>
                     
@@ -334,17 +327,16 @@ const SkillsSection = () => {
                           <TrendingUp size={16} />
                           {t("proficiency")}
                         </span>
-                        <span className="font-bold text-lg text-slate-800 dark:text-white px-3 py-1 bg-blue-100 dark:bg-blue-900/30 rounded-full">
+                        <span className="font-bold text-lg text-slate-800 dark:text-white px-3 py-1 bg-blue-50 dark:bg-blue-950/40 rounded-full">
                           {language.level}%
                         </span>
                       </div>
                       
                       <div className="relative w-full bg-slate-200 dark:bg-slate-700 rounded-full h-4 overflow-hidden">
                         <div
-                          className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500 rounded-full relative overflow-hidden transition-all duration-1000 ease-out"
+                          className="h-full bg-blue-500 rounded-full relative overflow-hidden transition-all duration-1000 ease-out"
                           style={{ width: `${language.level}%` }}
                         >
-                          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent" />
                         </div>
                       </div>
                     </div>

--- a/src/components/TeachingSection.tsx
+++ b/src/components/TeachingSection.tsx
@@ -82,7 +82,7 @@ export default function TeachingSection() {
   };
 
   return (
-    <section id="teaching" className="py-20" ref={ref}>
+    <section id="teaching" className="py-20 bg-slate-50 dark:bg-slate-950" ref={ref}>
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -90,7 +90,7 @@ export default function TeachingSection() {
           transition={{ duration: 0.5 }}
           className="text-center mb-12"
         >
-          <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-semibold mb-4 text-slate-900 dark:text-white">
             {t("title")}
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400">
@@ -105,13 +105,13 @@ export default function TeachingSection() {
           transition={{ duration: 0.5, delay: 0.2 }}
           className="max-w-md mx-auto mb-12"
         >
-          <div className="bg-gradient-to-r from-yellow-400 to-orange-500 p-1 rounded-2xl shadow-lg">
-            <div className="bg-white dark:bg-slate-900 rounded-2xl p-6 text-center">
-              <Award className="w-12 h-12 mx-auto mb-3 text-yellow-500" />
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm">
+            <div className="rounded-2xl p-6 text-center">
+              <Award className="w-12 h-12 mx-auto mb-3 text-slate-700 dark:text-slate-200" />
               <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
                 JLPT N1 {t("perfectScore")}
               </h3>
-              <p className="text-3xl font-bold text-transparent bg-gradient-to-r from-yellow-500 to-orange-500 bg-clip-text">
+              <p className="text-3xl font-bold text-slate-900 dark:text-white">
                 180/180
               </p>
               <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
@@ -132,10 +132,10 @@ export default function TeachingSection() {
             <motion.div
               key={index}
               variants={itemVariants}
-              className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow"
+              className="bg-white dark:bg-slate-900 rounded-xl p-6 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-shadow"
             >
-              <div className={`bg-gradient-to-r ${stat.color} p-3 rounded-lg w-fit mb-4`}>
-                <stat.icon className="w-6 h-6 text-white" />
+              <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg w-fit mb-4 border border-slate-200 dark:border-slate-700">
+                <stat.icon className="w-6 h-6 text-slate-700 dark:text-slate-200" />
               </div>
               <div className="text-3xl font-bold text-gray-900 dark:text-white mb-1">
                 {stat.value}
@@ -157,15 +157,15 @@ export default function TeachingSection() {
           <h3 className="text-2xl font-bold text-center mb-8 text-gray-900 dark:text-white">
             {t("experienceTitle")}
           </h3>
-          <div className="max-w-3xl mx-auto bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-900/20 dark:to-purple-900/20 rounded-2xl p-8">
-            <h4 className="text-xl font-semibold mb-4 text-indigo-600 dark:text-indigo-400">
+          <div className="max-w-3xl mx-auto bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl p-8 shadow-sm">
+            <h4 className="text-xl font-semibold mb-4 text-slate-900 dark:text-white">
               {t("newOriental")}
             </h4>
             <p className="text-gray-700 dark:text-gray-300 mb-4">
               {t("experienceDescription")}
             </p>
             <div className="grid md:grid-cols-2 gap-4">
-              <div className="bg-white/50 dark:bg-slate-800/50 rounded-lg p-4">
+              <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-4 border border-slate-200 dark:border-slate-700">
                 <h5 className="font-semibold text-gray-900 dark:text-white mb-2">
                   {t("achievements")}
                 </h5>
@@ -175,7 +175,7 @@ export default function TeachingSection() {
                   <li>• {t("achievement3")}</li>
                 </ul>
               </div>
-              <div className="bg-white/50 dark:bg-slate-800/50 rounded-lg p-4">
+              <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-4 border border-slate-200 dark:border-slate-700">
                 <h5 className="font-semibold text-gray-900 dark:text-white mb-2">
                   {t("specialties")}
                 </h5>
@@ -203,10 +203,10 @@ export default function TeachingSection() {
               <motion.div
                 key={index}
                 variants={itemVariants}
-                className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all hover:-translate-y-1"
+                className="bg-white dark:bg-slate-900 rounded-xl p-6 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all hover:-translate-y-1"
               >
-                <div className="bg-gradient-to-r from-indigo-500 to-purple-500 p-3 rounded-lg w-fit mb-4">
-                  <course.icon className="w-6 h-6 text-white" />
+                <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg w-fit mb-4 border border-slate-200 dark:border-slate-700">
+                  <course.icon className="w-6 h-6 text-slate-700 dark:text-slate-200" />
                 </div>
                 <h4 className="text-xl font-semibold mb-3 text-gray-900 dark:text-white">
                   {course.title}
@@ -220,7 +220,7 @@ export default function TeachingSection() {
                       key={idx}
                       className="flex items-start text-sm text-gray-600 dark:text-gray-400"
                     >
-                      <span className="text-indigo-500 mr-2">•</span>
+                      <span className="text-blue-500 mr-2">•</span>
                       {feature}
                     </li>
                   ))}

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -62,22 +62,22 @@ const TimelineSection = () => {
   const getCountryColor = (location?: string) => {
     switch (location) {
       case "china":
-        return "from-red-500 to-yellow-500";
+        return "bg-red-500";
       case "japan":
-        return "from-red-500 to-white";
+        return "bg-slate-500";
       default:
-        return "from-blue-500 to-purple-500";
+        return "bg-blue-500";
     }
   };
 
   const getCountryBg = (location?: string) => {
     switch (location) {
       case "china":
-        return "bg-gradient-to-br from-red-50 to-yellow-50 dark:from-red-950/20 dark:to-yellow-950/20";
+        return "bg-red-50 dark:bg-slate-900";
       case "japan":
-        return "bg-gradient-to-br from-red-50 to-slate-50 dark:from-red-950/20 dark:to-slate-950/20";
+        return "bg-slate-50 dark:bg-slate-900";
       default:
-        return "bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20";
+        return "bg-blue-50 dark:bg-slate-900";
     }
   };
 
@@ -89,109 +89,8 @@ const TimelineSection = () => {
 
 
       <div className="relative max-w-5xl mx-auto mt-20">
-        {/* Desktop flowing timeline paths */}
-        <div className="absolute inset-0 hidden lg:block pointer-events-none">
-          {eventsWithLocation.map((event, index) => {
-            if (index === eventsWithLocation.length - 1) return null;
-            
-            const isEven = index % 2 === 0;
-            const nextIsEven = (index + 1) % 2 === 0;
-            
-            // Calculate actual spacing based on the timeline layout
-            // space-y-32 = 8rem = 128px between cards
-            // Each card is approximately 200-250px in height
-            const cardSpacing = 128; // tailwind space-y-32
-            const cardHeight = 220; // estimated card height
-            const totalSpacing = cardSpacing + cardHeight;
-            
-            // Position from center of current card to center of next card
-            const yStart = index * totalSpacing + (cardHeight / 2);
-            const yEnd = (index + 1) * totalSpacing + (cardHeight / 2);
-            
-            return (
-              <motion.svg
-                key={`flow-${index}`}
-                className="absolute w-full overflow-visible"
-                style={{ 
-                  top: `${yStart}px`, 
-                  height: `${yEnd - yStart}px` 
-                }}
-                viewBox="0 0 800 400"
-                preserveAspectRatio="none"
-                initial={{ opacity: 0 }}
-                whileInView={{ opacity: 1 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.8, delay: index * 0.05 }}
-              >
-                <defs>
-                  <linearGradient id={`flow-gradient-${index}`}>
-                    <stop offset="0%" stopColor={event.location === 'china' ? '#ef4444' : event.location === 'japan' ? '#3b82f6' : '#8b5cf6'} stopOpacity="0.3" />
-                    <stop offset="50%" stopColor="#8b5cf6" stopOpacity="0.5" />
-                    <stop offset="100%" stopColor="#ec4899" stopOpacity="0.3" />
-                  </linearGradient>
-                  <filter id={`glow-${index}`}>
-                    <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-                    <feMerge>
-                      <feMergeNode in="coloredBlur"/>
-                      <feMergeNode in="SourceGraphic"/>
-                    </feMerge>
-                  </filter>
-                </defs>
-                
-                {/* Flowing path */}
-                <motion.path
-                  d={
-                    isEven
-                      ? nextIsEven
-                        ? "M 200 10 Q 150 200, 200 390" // 左→左 (gentle curve)
-                        : "M 200 10 Q 300 200, 600 390" // 左→右 (flowing S-curve)
-                      : nextIsEven
-                        ? "M 600 10 Q 500 200, 200 390" // 右→左 (flowing S-curve)
-                        : "M 600 10 Q 650 200, 600 390" // 右→右 (gentle curve)
-                  }
-                  stroke={`url(#flow-gradient-${index})`}
-                  strokeWidth="3"
-                  fill="none"
-                  filter={`url(#glow-${index})`}
-                  initial={{ pathLength: 0 }}
-                  whileInView={{ pathLength: 1 }}
-                  viewport={{ once: true }}
-                  transition={{ 
-                    pathLength: { duration: 1.5, delay: index * 0.1, ease: "easeInOut" }
-                  }}
-                />
-                
-                {/* Flowing particles */}
-                {[...Array(3)].map((_, i) => (
-                  <motion.circle
-                    key={`particle-${index}-${i}`}
-                    r="2"
-                    fill={event.location === 'china' ? '#fbbf24' : '#60a5fa'}
-                    filter={`url(#glow-${index})`}
-                  >
-                    <animateMotion
-                      dur={`${3 + i}s`}
-                      repeatCount="indefinite"
-                      begin={`${i * 0.5}s`}
-                      path={
-                        isEven
-                          ? nextIsEven
-                            ? "M 200 10 Q 150 200, 200 390"
-                            : "M 200 10 Q 300 200, 600 390"
-                          : nextIsEven
-                            ? "M 600 10 Q 500 200, 200 390"
-                            : "M 600 10 Q 650 200, 600 390"
-                      }
-                    />
-                  </motion.circle>
-                ))}
-              </motion.svg>
-            );
-          })}
-        </div>
-
-        {/* Mobile central line */}
-        <div className="absolute left-12 top-0 bottom-0 w-0.5 bg-gradient-to-b from-blue-400 via-purple-400 to-pink-400 lg:hidden" />
+        <div className="absolute inset-y-0 left-1/2 hidden lg:block w-px bg-slate-200 dark:bg-slate-700" />
+        <div className="absolute left-12 top-0 bottom-0 w-0.5 bg-slate-200 dark:bg-slate-700 lg:hidden" />
 
         {/* Timeline events */}
         <div className="relative space-y-16 lg:space-y-32">
@@ -240,13 +139,13 @@ const TimelineSection = () => {
                 )}
 
                 {/* Mobile timeline dot */}
-                <div className="absolute -left-20 top-8 w-4 h-4 bg-white dark:bg-slate-900 rounded-full border-2 border-blue-400 shadow-lg lg:hidden z-10" />
+                <div className="absolute -left-20 top-8 w-4 h-4 bg-white dark:bg-slate-900 rounded-full border-2 border-slate-300 dark:border-slate-600 shadow-sm lg:hidden z-10" />
 
                 {/* Desktop timeline dot - positioned at card edge */}
-                <div className={`absolute hidden lg:block w-6 h-6 bg-white dark:bg-slate-900 rounded-full shadow-lg z-20 ${
+                <div className={`absolute hidden lg:block w-6 h-6 bg-white dark:bg-slate-900 rounded-full shadow-sm z-20 border border-slate-200 dark:border-slate-700 ${
                   index % 2 === 0 ? "-right-3 top-8" : "-left-3 top-8"
                 }`}>
-                  <div className={`absolute inset-0.5 bg-gradient-to-r ${getCountryColor(event.location)} rounded-full`} />
+                  <div className={`absolute inset-1 ${getCountryColor(event.location)} rounded-full`} />
                 </div>
                 
                 {/* Connecting line from dot to card */}
@@ -257,15 +156,15 @@ const TimelineSection = () => {
                 }`} />
 
                 <motion.div
-                  className={`relative p-6 lg:p-8 rounded-2xl border-2 ${
+                  className={`relative p-6 lg:p-8 rounded-2xl border ${
                     isKyotoEvent 
-                      ? "border-blue-300 dark:border-blue-700 shadow-2xl shadow-blue-200/50 dark:shadow-blue-900/50" 
+                      ? "border-blue-300 dark:border-blue-600 shadow-md" 
                       : isStartupEvent
-                      ? "border-purple-300 dark:border-purple-700 shadow-2xl shadow-purple-200/50 dark:shadow-purple-900/50"
+                      ? "border-slate-300 dark:border-slate-600 shadow-md"
                       : event.special 
-                      ? "border-yellow-300 dark:border-yellow-700 shadow-2xl" 
-                      : "border-slate-200 dark:border-slate-700 shadow-lg"
-                  } ${getCountryBg(event.location)} backdrop-blur-sm overflow-hidden`}
+                      ? "border-amber-300 dark:border-amber-600 shadow-sm" 
+                      : "border-slate-200 dark:border-slate-700 shadow-sm"
+                  } ${getCountryBg(event.location)} overflow-hidden`}
                   whileHover={{ 
                     scale: 1.02,
                     transition: { type: "spring", stiffness: 300 }
@@ -298,11 +197,11 @@ const TimelineSection = () => {
                   <div className="flex items-start gap-4">
                     {/* Icon with unified design */}
                     <motion.div 
-                      className={`p-3 bg-gradient-to-br ${getCountryColor(event.location)} rounded-xl shadow-lg`}
+                      className="p-3 bg-white dark:bg-slate-900 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700"
                       whileHover={{ scale: 1.05 }}
                       transition={{ type: "spring", stiffness: 300 }}
                     >
-                      <Icon className="text-white" size={24} />
+                      <Icon className="text-slate-700 dark:text-slate-200" size={24} />
                     </motion.div>
 
                     <div className="flex-1">
@@ -322,7 +221,7 @@ const TimelineSection = () => {
                       {/* Title with special styling */}
                       <h4 className={`text-xl font-bold mb-2 ${
                         event.special 
-                          ? "bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent" 
+                          ? "text-blue-600 dark:text-blue-400" 
                           : "text-slate-900 dark:text-white"
                       }`}>
                         {event.title}
@@ -342,11 +241,6 @@ const TimelineSection = () => {
         </div>
       </div>
 
-      {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-1/4 left-0 w-96 h-96 bg-gradient-to-r from-blue-200 to-purple-200 dark:from-blue-900/20 dark:to-purple-900/20 rounded-full blur-3xl opacity-20" />
-        <div className="absolute bottom-1/4 right-0 w-96 h-96 bg-gradient-to-r from-pink-200 to-yellow-200 dark:from-pink-900/20 dark:to-yellow-900/20 rounded-full blur-3xl opacity-20" />
-      </div>
     </div>
   );
 };

--- a/src/components/URLShortenerSection.tsx
+++ b/src/components/URLShortenerSection.tsx
@@ -65,7 +65,7 @@ const URLShortenerSection = () => {
   };
 
   return (
-    <section id="urlshortener" className="py-20 sm:py-24 lg:py-32">
+    <section id="urlshortener" className="py-20 sm:py-24 lg:py-32 bg-white dark:bg-slate-950">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -73,11 +73,11 @@ const URLShortenerSection = () => {
           transition={{ duration: 0.6 }}
           className="text-center mb-12"
         >
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <Sparkles size={16} />
             {t("badge")}
           </div>
-          <h1 className="text-4xl sm:text-5xl font-bold gradient-text mb-4">
+          <h1 className="text-4xl sm:text-5xl font-semibold text-slate-900 dark:text-white mb-4">
             {t("title")}
           </h1>
           <p className="text-lg text-slate-600 dark:text-slate-400">
@@ -89,7 +89,7 @@ const URLShortenerSection = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-6 sm:p-8"
+          className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm p-6 sm:p-8"
         >
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
@@ -136,7 +136,7 @@ const URLShortenerSection = () => {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full py-3 px-6 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold rounded-lg hover:from-blue-700 hover:to-purple-700 transform hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              className="w-full py-3 px-6 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transform hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
             >
               {isLoading ? t("form.generating") : t("form.submit")}
             </button>

--- a/src/components/YopmailAccessSection.tsx
+++ b/src/components/YopmailAccessSection.tsx
@@ -69,7 +69,7 @@ const YopmailAccessSection = () => {
   };
 
   return (
-    <section id="yopmail" className="py-20 sm:py-24 lg:py-32">
+    <section id="yopmail" className="py-20 sm:py-24 lg:py-32 bg-white dark:bg-slate-950">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -77,11 +77,11 @@ const YopmailAccessSection = () => {
           transition={{ duration: 0.6 }}
           className="text-center mb-12"
         >
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 text-sm font-medium mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 text-sm font-medium mb-6 border border-slate-200 dark:border-slate-700 shadow-sm">
             <Sparkles size={16} />
             {t("badge")}
           </div>
-          <h1 className="text-4xl sm:text-5xl font-bold gradient-text mb-4">
+          <h1 className="text-4xl sm:text-5xl font-semibold text-slate-900 dark:text-white mb-4">
             {t("title")}
           </h1>
           <p className="text-lg text-slate-600 dark:text-slate-400">
@@ -93,7 +93,7 @@ const YopmailAccessSection = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-6 sm:p-8"
+          className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm p-6 sm:p-8"
         >
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
@@ -111,7 +111,7 @@ const YopmailAccessSection = () => {
                   value={username}
                   onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, ''))}
                   placeholder={t("form.usernamePlaceholder")}
-                  className="w-full pl-10 pr-20 py-3 border border-slate-200 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-transparent dark:bg-slate-900 dark:text-white transition-all duration-200"
+                  className="w-full pl-10 pr-20 py-3 border border-slate-200 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-slate-900 dark:text-white transition-all duration-200"
                   required
                 />
                 <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 text-sm">
@@ -127,7 +127,7 @@ const YopmailAccessSection = () => {
               <button
                 type="submit"
                 disabled={isLoading || !username}
-                className="flex-1 py-3 px-6 bg-gradient-to-r from-emerald-600 to-teal-600 text-white font-semibold rounded-lg hover:from-emerald-700 hover:to-teal-700 transform hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+                className="flex-1 py-3 px-6 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transform hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
               >
                 {isLoading ? t("form.generating") : t("form.createShortUrl")}
               </button>
@@ -136,7 +136,7 @@ const YopmailAccessSection = () => {
                 type="button"
                 onClick={openYopmailDirect}
                 disabled={!username}
-                className="px-6 py-3 border border-emerald-600 text-emerald-600 dark:text-emerald-400 dark:border-emerald-400 font-semibold rounded-lg hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-6 py-3 border border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400 font-semibold rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <ArrowRight size={18} />
               </button>
@@ -157,10 +157,10 @@ const YopmailAccessSection = () => {
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="mt-6 p-6 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg"
+              className="mt-6 p-6 bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-900 rounded-lg"
             >
               <div className="flex items-center gap-2 mb-3">
-                <CheckCircle className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                <CheckCircle className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                 <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
                   {t("result.title")}
                 </p>
@@ -188,7 +188,7 @@ const YopmailAccessSection = () => {
                     </span>
                     <button
                       onClick={copyToClipboard}
-                      className="p-1 text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                      className="p-1 text-slate-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                       title={t("result.copy")}
                     >
                       <Copy size={16} />
@@ -197,7 +197,7 @@ const YopmailAccessSection = () => {
                       href={shortUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="p-1 text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                      className="p-1 text-slate-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                       title={t("result.open")}
                     >
                       <ExternalLink size={16} />
@@ -207,7 +207,7 @@ const YopmailAccessSection = () => {
               </div>
               
               {copied && (
-                <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-2">
+                <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
                   {t("result.copied")}
                 </p>
               )}
@@ -218,12 +218,12 @@ const YopmailAccessSection = () => {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.6, delay: 0.4 }}
-            className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg"
+            className="mt-6 p-4 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg"
           >
-            <h3 className="text-sm font-medium text-blue-900 dark:text-blue-300 mb-2">
+            <h3 className="text-sm font-medium text-slate-900 dark:text-slate-200 mb-2">
               {t("info.title")}
             </h3>
-            <ul className="text-xs text-blue-800 dark:text-blue-400 space-y-1">
+            <ul className="text-xs text-slate-600 dark:text-slate-400 space-y-1">
               <li>• {t("info.unlimited")}</li>
               <li>• {t("info.noPassword")}</li>
               <li>• {t("info.retention")}</li>

--- a/src/components/ZennFeed.tsx
+++ b/src/components/ZennFeed.tsx
@@ -88,7 +88,7 @@ export default function ZennFeed() {
       <section className="py-20">
         <div className="container mx-auto px-4">
           <div className="text-center">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-green-500 to-teal-600 text-white rounded-full animate-pulse">
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 rounded-full border border-slate-200 dark:border-slate-700 shadow-sm">
               <BookOpen size={20} />
               <span>{t("loading")}</span>
             </div>
@@ -103,7 +103,7 @@ export default function ZennFeed() {
   }
 
   return (
-    <section id="blog" className="py-20 bg-gradient-to-b from-white to-slate-50 dark:from-slate-900 dark:to-slate-950">
+    <section id="blog" className="py-20 bg-white dark:bg-slate-950">
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -111,7 +111,7 @@ export default function ZennFeed() {
           transition={{ duration: 0.5 }}
           className="text-center mb-12"
         >
-          <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-green-600 to-teal-600 bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-5xl font-semibold mb-4 text-slate-900 dark:text-white">
             {t("title")}
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-400">
@@ -133,15 +133,13 @@ export default function ZennFeed() {
               rel="noopener noreferrer"
               className="block"
             >
-              <div className="relative p-8 bg-gradient-to-r from-green-500 to-teal-600 rounded-3xl shadow-2xl overflow-hidden group hover:shadow-3xl transition-all duration-300">
-                <div className="absolute inset-0 bg-black/10 group-hover:bg-black/20 transition-colors duration-300" />
-                
-                <div className="relative z-10 text-white">
+              <div className="relative p-8 bg-white dark:bg-slate-900 rounded-3xl border border-slate-200 dark:border-slate-700 shadow-sm overflow-hidden group hover:shadow-md transition-all duration-300">
+                <div className="relative z-10 text-slate-900 dark:text-white">
                   <div className="flex items-center gap-2 mb-4">
-                    <span className="px-3 py-1 bg-white/20 backdrop-blur-sm rounded-full text-sm font-semibold">
+                    <span className="px-3 py-1 bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 rounded-full text-sm font-semibold">
                       {t("featured")}
                     </span>
-                    <span className="px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm">
+                    <span className="px-3 py-1 bg-slate-100 dark:bg-slate-800 rounded-full text-sm text-slate-600 dark:text-slate-300">
                       {formatDate(articles[0].pubDate)}
                     </span>
                   </div>
@@ -151,16 +149,16 @@ export default function ZennFeed() {
                   </h3>
                   
                   <div
-                    className="text-white/80 mb-6 line-clamp-2"
+                    className="text-slate-600 dark:text-slate-400 mb-6 line-clamp-2"
                     dangerouslySetInnerHTML={{ __html: articles[0].description }}
                   />
                   
                   <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
                       <User size={16} />
                       <span className="text-sm">{articles[0].creator}</span>
                     </div>
-                    <div className="flex items-center gap-2 group-hover:gap-3 transition-all">
+                    <div className="flex items-center gap-2 group-hover:gap-3 transition-all text-blue-600 dark:text-blue-400">
                       <span className="text-sm font-semibold">{t("readMore")}</span>
                       <ExternalLink size={16} />
                     </div>
@@ -190,13 +188,13 @@ export default function ZennFeed() {
                 rel="noopener noreferrer"
                 className="block h-full"
               >
-                <div className="h-full bg-white dark:bg-slate-800 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-6 border border-gray-100 dark:border-gray-700 hover:border-green-300 dark:hover:border-green-600">
+                <div className="h-full bg-white dark:bg-slate-900 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300 p-6 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600">
                   <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 mb-3">
                     <Calendar size={14} />
                     <span>{formatDate(article.pubDate)}</span>
                   </div>
                   
-                  <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors line-clamp-2">
+                  <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2">
                     {article.title}
                   </h3>
                   
@@ -212,7 +210,7 @@ export default function ZennFeed() {
                     </div>
                     <ExternalLink
                       size={16}
-                      className="text-gray-400 group-hover:text-green-600 dark:group-hover:text-green-400 transition-colors"
+                      className="text-slate-400 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
                     />
                   </div>
                 </div>
@@ -232,7 +230,7 @@ export default function ZennFeed() {
             href="https://zenn.dev/ryoushin"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-green-600 to-teal-600 text-white rounded-full font-semibold hover:shadow-lg transform hover:scale-105 transition-all duration-300"
+            className="inline-flex items-center gap-3 px-8 py-4 bg-blue-600 text-white rounded-full font-semibold hover:shadow-md transform hover:scale-105 transition-all duration-300"
           >
             <span>{t("viewAllArticles")}</span>
             <ExternalLink size={18} />


### PR DESCRIPTION
### Motivation

- Reduce the current “AI-generated” visual feel by moving the site toward a cleaner, Apple-inspired neutral aesthetic with subtler accents and typography.
- Replace heavy gradients, glassmorphism, and glowing effects with restrained borders, muted backgrounds and consistent accent color to improve legibility and perceived quality.

### Description

- Updated the global theme and typography in `src/app/globals.css` to a neutral Apple-like palette and added `SF Pro` system fonts, removed/neutralized global gradient/glass/glow utilities and simplified selection/scrollbar styles.
- Simplified the Hero and Navigation headers to remove bright gradients and large background blobs, replaced gradient headings with neutral typography, and unified button/element treatments in `src/components/HeroSection.tsx` and `src/components/Navigation.tsx`.
- Reworked card, badge and list styles across major sections to a white/neutral background with subtle borders and smaller shadows, and standardized accent usage in `src/components/AboutSection.tsx`, `ProjectsSection.tsx`, `SkillsSection.tsx`, `ResearchSection.tsx`, `TeachingSection.tsx`, `GallerySection.tsx`, `TimelineSection.tsx`, `LatestZennArticle.tsx`, `ZennFeed.tsx`, `URLShortenerSection.tsx`, and `YopmailAccessSection.tsx`.
- Simplified interactive/UI details: QR modal backdrops, image modal controls, timeline markers, badges and status chips were made more minimal and consistent (see modified files above for precise class changes).

### Testing

- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, Next compiled and served the app successfully and responded `GET /ja 200` during verification.
- Captured a rendered screenshot of the updated homepage using a Playwright script that visited `http://127.0.0.1:3000/ja` and produced `artifacts/apple-style-home.png` (screenshot successful).
- No automated unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696baa954f448324b0824a4d3c9d1464)