### PR TITLE
Fix: throttle scroll listener to prevent jank (#16)

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -85,10 +85,12 @@ const Navigation = () => {
 
   useEffect(() => {
     let ticking = false;
+    let rafId: number;
     const handleScroll = () => {
       if (!ticking) {
-        requestAnimationFrame(() => {
-          setIsScrolled(window.scrollY > 50);
+        rafId = requestAnimationFrame(() => {
+          const shouldBeScrolled = window.scrollY > 50;
+          setIsScrolled(prev => prev === shouldBeScrolled ? prev : shouldBeScrolled);
           ticking = false;
         });
         ticking = true;
@@ -96,7 +98,10 @@ const Navigation = () => {
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      cancelAnimationFrame(rafId);
+    };
   }, []);
 
   const activeSection = currentSection;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -84,11 +84,18 @@ const Navigation = () => {
   ];
 
   useEffect(() => {
+    let ticking = false;
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 50);
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          setIsScrolled(window.scrollY > 50);
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 


### PR DESCRIPTION
## Summary
- Throttle the scroll event listener in `Navigation.tsx` using `requestAnimationFrame` to prevent excessive re-renders (~60+/sec) during scrolling
- Add `{ passive: true }` to the scroll event listener for improved scroll performance
- Fixes the jank caused by unthrottled `setIsScrolled` calls

Closes #16

## Test plan
- [ ] Scroll the page and verify navigation background transition still works (appears after scrolling past 50px)
- [ ] Confirm smooth scrolling with no jank using browser DevTools Performance tab
- [ ] Verify no regressions in navigation behavior (sticky header, active section highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)