### PR TITLE
fix: remove excessive backdrop-filter blur to reduce GPU load

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,16 +94,12 @@ body {
 
 /* Glassmorphism utility classes */
 .glass {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .glass-dark {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -211,7 +211,7 @@ const Navigation = () => {
             {/* Theme Toggle */}
             <motion.button
               onClick={toggleTheme}
-              className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+              className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               aria-label="Toggle dark mode"
@@ -249,7 +249,7 @@ const Navigation = () => {
             <div className="relative language-menu">
               <motion.button
                 onClick={() => setShowLangMenu(!showLangMenu)}
-                className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+                className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -264,7 +264,7 @@ const Navigation = () => {
               <AnimatePresence>
                 {showLangMenu && (
                   <motion.div
-                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
+                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white dark:bg-slate-800 rounded-2xl shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
                     initial={{ opacity: 0, y: -10, scale: 0.95 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
                     exit={{ opacity: 0, y: -10, scale: 0.95 }}
@@ -295,7 +295,7 @@ const Navigation = () => {
             {/* Mobile Menu Button */}
             <motion.button
               onClick={() => setShowMoreMenu(!showMoreMenu)}
-              className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
+              className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -125,7 +125,7 @@ const Navigation = () => {
       <motion.nav
         className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
           isScrolled
-            ? "bg-white/95 dark:bg-slate-950/95 backdrop-blur-md shadow-lg border-b border-slate-200/20 dark:border-slate-800/20"
+            ? "bg-white dark:bg-slate-950 shadow-lg border-b border-slate-200/20 dark:border-slate-800/20"
             : "bg-transparent"
         }`}
         initial={{ y: -100 }}

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -185,7 +185,7 @@ const SkillsSection = () => {
               return (
                 <div
                   key={categoryIndex}
-                  className="group relative overflow-hidden bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
                 >
                   {/* Background gradient */}
                   <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
@@ -251,7 +251,7 @@ const SkillsSection = () => {
         {/* Certifications */}
         <div className="mb-24">
           <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
               <div className="p-2 bg-gradient-to-r from-amber-500 to-orange-600 rounded-lg shadow-lg">
                 <Award className="text-white" size={20} />
               </div>
@@ -267,7 +267,7 @@ const SkillsSection = () => {
               {certifications.list.map((cert, index) => (
                 <div
                   key={index}
-                  className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl p-6 border border-slate-200/50 dark:border-slate-700/50 shadow-lg hover:shadow-xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-2xl p-6 border border-slate-200/50 dark:border-slate-700/50 shadow-lg hover:shadow-xl transition-all duration-200"
                 >
                   
                   <div className="relative z-10">
@@ -297,7 +297,7 @@ const SkillsSection = () => {
         {/* Language Skills */}
         <div>
           <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
               <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-600 rounded-lg shadow-lg">
                 <Globe className="text-white" size={20} />
               </div>
@@ -310,7 +310,7 @@ const SkillsSection = () => {
               {languages.map((language, index) => (
                 <div
                   key={index}
-                  className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
                 >
                   {/* Background gradient */}
                   <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-emerald-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-emerald-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -262,7 +262,7 @@ const TimelineSection = () => {
                       : event.special
                       ? "border-yellow-300 dark:border-yellow-700 shadow-2xl" 
                       : "border-slate-200 dark:border-slate-700 shadow-lg"
-                  } ${getCountryBg(event.location)} backdrop-blur-sm overflow-hidden`}
+                  } ${getCountryBg(event.location)} overflow-hidden`}
                   whileHover={{ 
                     scale: 1.02,
                     transition: { type: "spring", stiffness: 300 }


### PR DESCRIPTION
## Summary
- Removed `backdrop-filter: blur()` from `.glass` / `.glass-dark` in `globals.css` and replaced with higher-opacity solid backgrounds (`rgba 0.85`)
- Removed `backdrop-blur-md` from `Navigation.tsx` scrolled state, using fully opaque `bg-white` / `bg-slate-950`
- Removed all `backdrop-blur-xl` / `backdrop-blur-sm` from `SkillsSection.tsx` skill cards, certification cards, and language cards
- Removed `backdrop-blur-sm` from `TimelineSection.tsx` timeline cards

Each `backdrop-filter` instance creates a separate GPU compositing layer. Removing these reduces GPU overhead without meaningful visual regression since the backgrounds are now opaque or near-opaque.

Closes #18

## Test plan
- [ ] Verify navigation bar still looks correct when scrolled (opaque background, no transparency glitch)
- [ ] Verify skills section cards render with solid backgrounds in both light and dark mode
- [ ] Verify certification and language cards look correct
- [ ] Verify timeline cards render properly
- [ ] Confirm no remaining `backdrop-blur` or `backdrop-filter` usage in the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)