### PR TITLE
fix: convert SkillsSection to Server Component

### DIFF
--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import {
   Code,
   Monitor,
@@ -32,8 +30,8 @@ import {
   SiTensorflow,
 } from "react-icons/si";
 
-const SkillsSection = () => {
-  const t = useTranslations("skills");
+const SkillsSection = async () => {
+  const t = await getTranslations("skills");
 
   const skillCategories = [
     {


### PR DESCRIPTION
## Summary
- Removed `"use client"` directive from `SkillsSection.tsx`
- Replaced `useTranslations` (client hook) with `getTranslations` from `next-intl/server`
- Made the component `async` to support the awaited `getTranslations` call

This component has no client-side features (no useState, useEffect, event handlers, or framer-motion), so it can be fully rendered as a Server Component, improving performance by reducing the client JS bundle.

Closes #21

## Test plan
- [ ] Verify the Skills section renders correctly in all three locales (ja/en/zh)
- [ ] Confirm no hydration errors in the browser console
- [ ] Check that skill bars, certifications, and language proficiency display as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)