### PR TITLE
fix: remove CSS smooth scroll conflicting with JS scrollIntoView

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -94,7 +94,7 @@ export default async function RootLayout({
   const messages = await getMessages({ locale: validLocale });
 
   return (
-    <html lang={validLocale} className="scroll-smooth" suppressHydrationWarning data-oid="bphv6.8">
+    <html lang={validLocale} suppressHydrationWarning data-oid="bphv6.8">
       <head data-oid="8k2pgtd">
         {/* Theme script to prevent flash */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,7 +51,6 @@
 }
 
 html {
-  scroll-behavior: smooth;
   overflow-x: hidden;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- Removed `scroll-behavior: smooth` from `globals.css` html rule
- Removed `scroll-smooth` Tailwind class from `<html>` element in layout.tsx
- JS-based `scrollIntoView({ behavior: "smooth" })` in `useScrollNavigation.ts` remains as the single source of smooth scrolling

Closes #23

## Test plan
- [ ] Verify smooth scrolling still works when clicking navigation links
- [ ] Verify initial page load with hash does not exhibit sluggish scroll
- [ ] Verify `useScrollNavigation` hook drives all smooth scroll behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)