### PR TITLE
Add sizes prop to Image components for optimized loading

### DIFF
--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -219,6 +219,7 @@ const GallerySection = () => {
                     alt={filteredImages[selectedImage].alt}
                     width={1000}
                     height={700}
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 1000px"
                     className="w-auto h-auto max-h-[70vh] object-contain"
                   />
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -344,11 +344,12 @@ const HeroSection = () => {
                                         {platform.id === 'wechat' ? tSocialActions('wechatQR') : tSocialActions('whatsappQR')}
                                       </h3>
                                       <div className="bg-white p-2 sm:p-4 rounded-xl">
-                                        <Image 
-                                          src={platform.qrCode} 
-                                          alt={`${platform.name} QR Code`} 
-                                          width={200} 
-                                          height={200} 
+                                        <Image
+                                          src={platform.qrCode}
+                                          alt={`${platform.name} QR Code`}
+                                          width={200}
+                                          height={200}
+                                          sizes="240px"
                                           className="rounded-lg w-full max-w-60 mx-auto"
                                         />
                                       </div>
@@ -387,11 +388,12 @@ const HeroSection = () => {
                               {platform.icon ? (
                                 <platform.icon size={18} className="sm:w-5 sm:h-5 relative z-10 group-hover:text-white transition-colors duration-200" />
                               ) : (
-                                <Image 
-                                  src={platform.iconPath!} 
-                                  alt={platform.name} 
-                                  width={16} 
-                                  height={16} 
+                                <Image
+                                  src={platform.iconPath!}
+                                  alt={platform.name}
+                                  width={16}
+                                  height={16}
+                                  sizes="20px"
                                   className="relative z-10 w-4.5 h-4.5 sm:w-5 sm:h-5"
                                 />
                               )}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -148,6 +148,7 @@ const Navigation = () => {
                 alt="Logo"
                 width={24}
                 height={24}
+                sizes="36px"
                 className="relative rounded-full border-2 border-white dark:border-slate-800 shadow-lg sm:w-8 sm:h-8"
               />
             </div>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -276,6 +276,7 @@ const TimelineSection = () => {
                         alt="Kyoto University"
                         width={160}
                         height={160}
+                        sizes="160px"
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- Added `sizes` prop to all `next/image` `<Image>` components that were missing it, preventing the browser from downloading unnecessarily large images
- Fixed components: Navigation (logo), HeroSection (QR code + social icon), TimelineSection (Kyoto U logo), GallerySection (modal image)
- GallerySection grid images already had correct `sizes`; added responsive sizes to the modal image

Closes #22

## Test plan
- [ ] Verify images load correctly across all viewports (mobile, tablet, desktop)
- [ ] Check Network tab to confirm smaller image variants are served on narrow viewports
- [ ] Verify no visual regressions in Navigation logo, HeroSection social icons/QR codes, TimelineSection, and GallerySection

🤖 Generated with [Claude Code](https://claude.com/claude-code)