### PR TITLE
Fix theme hydration mismatch

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -18,21 +18,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    // After mounting, always use device preference
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const deviceTheme = prefersDark ? "dark" : "light";
-    
-    setTheme(deviceTheme);
-    
-    // Ensure proper theme classes are set based on device preference
-    if (deviceTheme === "dark") {
-      document.documentElement.classList.add("dark");
-      document.documentElement.classList.remove("light");
-    } else {
-      document.documentElement.classList.add("light");
-      document.documentElement.classList.remove("dark");
-    }
-    
+    // Read from DOM — the inline script in <head> already set the correct class
+    const isDark = document.documentElement.classList.contains("dark");
+    setTheme(isDark ? "dark" : "light");
     setMounted(true);
   }, []);
 


### PR DESCRIPTION
## Summary
- Read the theme from `document.documentElement.classList` in `useEffect` instead of re-running `window.matchMedia`
- The inline `<script>` in `<head>` (`src/app/theme-script.ts`) already sets the correct `dark`/`light` class before React hydrates, so ThemeContext just needs to read that state
- Eliminates the visible light-to-dark flash for users who prefer dark mode

Closes #32

## Test plan
- [ ] Load the site with OS dark mode enabled and verify no light-to-dark flash
- [ ] Load the site with OS light mode enabled and verify correct theme
- [ ] Toggle theme via the UI button and verify it switches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)