### PR TITLE
fix: migrate framer-motion to LazyMotion (m) for bundle size reduction

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Noto_Sans_JP } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import Navigation from "@/components/Navigation";
+import MotionProvider from "@/components/MotionProvider";
 import StructuredData from "@/components/StructuredData";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { themeScript } from "../theme-script";
@@ -135,23 +136,25 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider messages={messages} data-oid="q3ce1r0">
           <ThemeProvider>
-            <Navigation data-oid="hk5vrem" />
-            <main className="min-h-screen w-full overflow-x-hidden" data-oid="cjsbd45">
-              {children}
-            </main>
-            <footer className="bg-slate-900 text-white py-6 sm:py-8 w-full overflow-x-hidden" data-oid="9d4m8i:">
-              <div
-                className="container mx-auto px-4 sm:px-6 text-center max-w-7xl"
-                data-oid="67z3cll"
-              >
-                <p className="text-xs sm:text-sm opacity-80" data-oid="lswazss">
-                  {messages.footer.copyright}
-                </p>
-                <p className="text-xs opacity-60 mt-2" data-oid="ujmiq13">
-                  {messages.footer.builtWith}
-                </p>
-              </div>
-            </footer>
+            <MotionProvider>
+              <Navigation data-oid="hk5vrem" />
+              <main className="min-h-screen w-full overflow-x-hidden" data-oid="cjsbd45">
+                {children}
+              </main>
+              <footer className="bg-slate-900 text-white py-6 sm:py-8 w-full overflow-x-hidden" data-oid="9d4m8i:">
+                <div
+                  className="container mx-auto px-4 sm:px-6 text-center max-w-7xl"
+                  data-oid="67z3cll"
+                >
+                  <p className="text-xs sm:text-sm opacity-80" data-oid="lswazss">
+                    {messages.footer.copyright}
+                  </p>
+                  <p className="text-xs opacity-60 mt-2" data-oid="ujmiq13">
+                    {messages.footer.builtWith}
+                  </p>
+                </div>
+              </footer>
+            </MotionProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import {
   Briefcase,
@@ -51,7 +51,7 @@ const AboutSection = () => {
     <section id="about" className="pt-32 pb-24 bg-gradient-to-b from-white to-slate-50/50 dark:from-slate-950 dark:to-slate-900/50 overflow-hidden" ref={ref}>
       <div className="container mx-auto px-4 sm:px-6 max-w-7xl">
         {/* Header */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: -20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: -20 }}
           transition={{ duration: 0.5 }}
@@ -67,18 +67,18 @@ const AboutSection = () => {
           <p className="text-base sm:text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto px-4">
             {t("subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
         {/* Main Content Grid */}
         <div className="max-w-6xl mx-auto">
           {/* Current Status Cards */}
-          <motion.div
+          <m.div
             variants={containerVariants}
             initial="hidden"
             animate={inView ? "visible" : "hidden"}
             className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6 mb-12 sm:mb-16"
           >
-            <motion.div
+            <m.div
               variants={itemVariants}
               className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
             >
@@ -97,9 +97,9 @@ const AboutSection = () => {
                   {skillsT("jobTitle")}
                 </p>
               </div>
-            </motion.div>
+            </m.div>
 
-            <motion.div
+            <m.div
               variants={itemVariants}
               className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
             >
@@ -112,9 +112,9 @@ const AboutSection = () => {
                   {t("experience")}
                 </h3>
               </div>
-            </motion.div>
+            </m.div>
 
-            <motion.div
+            <m.div
               variants={itemVariants}
               className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
             >
@@ -133,11 +133,11 @@ const AboutSection = () => {
                   {skillsT("yearsExperience", { years: "7" })}
                 </p>
               </div>
-            </motion.div>
-          </motion.div>
+            </m.div>
+          </m.div>
 
           {/* Specialization Fields */}
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: 20 }}
             animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
             transition={{ delay: 0.2 }}
@@ -148,7 +148,7 @@ const AboutSection = () => {
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
               {fields.map((field, index) => (
-                <motion.div
+                <m.div
                   key={index}
                   initial={{ opacity: 0, x: -20 }}
                   animate={inView ? { opacity: 1, x: 0 } : { opacity: 0, x: -20 }}
@@ -159,10 +159,10 @@ const AboutSection = () => {
                   <p className="text-slate-700 dark:text-slate-300 font-medium text-sm sm:text-base">
                     {field}
                   </p>
-                </motion.div>
+                </m.div>
               ))}
             </div>
-          </motion.div>
+          </m.div>
 
 
           {/* Timeline Section */}

--- a/src/components/MotionProvider.tsx
+++ b/src/components/MotionProvider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { LazyMotion, domAnimation } from "framer-motion";
+
+export default function MotionProvider({ children }: { children: React.ReactNode }) {
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>;
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { motion, AnimatePresence } from "framer-motion";
+import { m, AnimatePresence } from "framer-motion";
 import { usePathname, useRouter, useParams } from "next/navigation";
 import { Menu, X, Moon, Sun } from "lucide-react";
 import Image from "next/image";
@@ -122,7 +122,7 @@ const Navigation = () => {
 
   return (
     <>
-      <motion.nav
+      <m.nav
         className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
           isScrolled
             ? "bg-white/95 dark:bg-slate-950/95 backdrop-blur-md shadow-lg border-b border-slate-200/20 dark:border-slate-800/20"
@@ -135,7 +135,7 @@ const Navigation = () => {
       <div className="container mx-auto px-3 sm:px-4 lg:px-6 max-w-7xl">
         <div className="flex items-center justify-between h-14 sm:h-16 lg:h-20">
           {/* Logo */}
-          <motion.div
+          <m.div
             className="flex items-center gap-2 sm:gap-4 cursor-pointer"
             onClick={() => navigateTo("hero")}
             whileHover={{ scale: 1.02 }}
@@ -159,23 +159,24 @@ const Navigation = () => {
                 {namesT("english")}
               </p>
             </div>
-          </motion.div>
+          </m.div>
 
           {/* Desktop Navigation */}
           <div className="hidden lg:flex items-center gap-1 xl:gap-2">
             {/* Primary Navigation Items */}
             {primaryNavItems.map((item) => (
-              <motion.div
+              <m.div
                 key={item.key}
                 className="relative"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
                 {activeSection === item.sectionId && (
-                  <motion.div
+                  <m.div
                     className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full"
-                    layoutId="activeNavItem"
-                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: 0.2 }}
                   />
                 )}
                 <button
@@ -188,11 +189,11 @@ const Navigation = () => {
                 >
                   {t(item.key)}
                 </button>
-              </motion.div>
+              </m.div>
             ))}
 
             {/* Hamburger Menu Button */}
-            <motion.button
+            <m.button
               onClick={() => setShowMoreMenu(!showMoreMenu)}
               className={`p-2 lg:p-3 rounded-full transition-all duration-300 ${
                 secondaryNavItems.some(item => activeSection === item.sectionId)
@@ -203,13 +204,13 @@ const Navigation = () => {
               whileTap={{ scale: 0.95 }}
             >
               <Menu size={16} className="lg:w-5 lg:h-5" />
-            </motion.button>
+            </m.button>
           </div>
 
           {/* Right Side Controls */}
           <div className="flex items-center gap-1 sm:gap-2 lg:gap-3">
             {/* Theme Toggle */}
-            <motion.button
+            <m.button
               onClick={toggleTheme}
               className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
               whileHover={{ scale: 1.05 }}
@@ -219,7 +220,7 @@ const Navigation = () => {
               {mounted ? (
                 <AnimatePresence mode="wait">
                   {theme === "dark" ? (
-                    <motion.div
+                    <m.div
                       key="sun"
                       initial={{ rotate: -90, opacity: 0 }}
                       animate={{ rotate: 0, opacity: 1 }}
@@ -227,9 +228,9 @@ const Navigation = () => {
                       transition={{ duration: 0.15 }}
                     >
                       <Sun size={14} className="sm:w-[18px] sm:h-[18px] lg:w-5 lg:h-5" />
-                    </motion.div>
+                    </m.div>
                   ) : (
-                    <motion.div
+                    <m.div
                       key="moon"
                       initial={{ rotate: 90, opacity: 0 }}
                       animate={{ rotate: 0, opacity: 1 }}
@@ -237,17 +238,17 @@ const Navigation = () => {
                       transition={{ duration: 0.15 }}
                     >
                       <Moon size={14} className="sm:w-[18px] sm:h-[18px] lg:w-5 lg:h-5" />
-                    </motion.div>
+                    </m.div>
                   )}
                 </AnimatePresence>
               ) : (
                 <div className="w-[14px] h-[14px] sm:w-[18px] sm:h-[18px] lg:w-5 lg:h-5" />
               )}
-            </motion.button>
+            </m.button>
 
             {/* Language Selector */}
             <div className="relative language-menu">
-              <motion.button
+              <m.button
                 onClick={() => setShowLangMenu(!showLangMenu)}
                 className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
                 whileHover={{ scale: 1.05 }}
@@ -259,11 +260,11 @@ const Navigation = () => {
                 <span className="hidden sm:block text-xs lg:text-sm font-medium truncate max-w-16 lg:max-w-none">
                   {languages.find(lang => lang.code === locale)?.name || locale.toUpperCase()}
                 </span>
-              </motion.button>
+              </m.button>
 
               <AnimatePresence>
                 {showLangMenu && (
-                  <motion.div
+                  <m.div
                     className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
                     initial={{ opacity: 0, y: -10, scale: 0.95 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -271,7 +272,7 @@ const Navigation = () => {
                     transition={{ duration: 0.2 }}
                   >
                     {languages.map((language) => (
-                      <motion.button
+                      <m.button
                         key={language.code}
                         onClick={() => handleLanguageChange(language.code)}
                         className={`w-full text-left px-3 lg:px-4 py-2 lg:py-3 text-xs lg:text-sm font-medium transition-all duration-200 ${
@@ -285,32 +286,32 @@ const Navigation = () => {
                           <span className="text-sm lg:text-lg">{language.flag}</span>
                           <span className="truncate">{language.name}</span>
                         </span>
-                      </motion.button>
+                      </m.button>
                     ))}
-                  </motion.div>
+                  </m.div>
                 )}
               </AnimatePresence>
             </div>
 
             {/* Mobile Menu Button */}
-            <motion.button
+            <m.button
               onClick={() => setShowMoreMenu(!showMoreMenu)}
               className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
               <Menu size={14} className="sm:w-[18px] sm:h-[18px]" />
-            </motion.button>
+            </m.button>
           </div>
         </div>
 
         </div>
-      </motion.nav>
+      </m.nav>
 
       {/* Full Screen Menu Portal - Outside Navigation */}
       <AnimatePresence>
         {showMoreMenu && (
-          <motion.div
+          <m.div
             className="fixed inset-0 bg-white dark:bg-slate-950"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -328,18 +329,18 @@ const Navigation = () => {
             
             {/* Close Button */}
             <div className="absolute top-6 right-6 z-[100001]">
-              <motion.button
+              <m.button
                 onClick={() => setShowMoreMenu(false)}
                 className="p-3 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all duration-300 shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
               >
                 <X size={24} />
-              </motion.button>
+              </m.button>
             </div>
 
             <div className="flex items-center justify-center min-h-screen p-4 sm:p-6">
-              <motion.div
+              <m.div
                 className="text-center w-full max-w-4xl lg:max-w-6xl"
                 initial={{ y: 50, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
@@ -350,7 +351,7 @@ const Navigation = () => {
                 <div className="block lg:hidden">
                   <div className="space-y-3 sm:space-y-4 max-w-xs sm:max-w-sm mx-auto">
                     {[...primaryNavItems, ...secondaryNavItems].map((item, index) => (
-                      <motion.button
+                      <m.button
                         key={item.key}
                         onClick={() => navigateTo(item.sectionId)}
                         className={`block w-full text-center px-4 sm:px-6 py-3 sm:py-4 rounded-xl font-semibold text-base sm:text-lg transition-all duration-300 ${
@@ -365,7 +366,7 @@ const Navigation = () => {
                         transition={{ delay: 0.1 + index * 0.05, duration: 0.3 }}
                       >
                         {t(item.key)}
-                      </motion.button>
+                      </m.button>
                     ))}
                   </div>
                 </div>
@@ -373,19 +374,19 @@ const Navigation = () => {
                 {/* Desktop Simple Menu */}
                 <div className="hidden lg:block">
                   {/* Menu Title */}
-                  <motion.h2
+                  <m.h2
                     className="text-3xl sm:text-4xl md:text-6xl font-black gradient-text mb-12 sm:mb-16"
                     initial={{ y: 30, opacity: 0 }}
                     animate={{ y: 0, opacity: 1 }}
                     transition={{ delay: 0.2, duration: 0.4 }}
                   >
                     Menu
-                  </motion.h2>
+                  </m.h2>
 
                   {/* All Navigation Items in Grid */}
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 max-w-2xl md:max-w-4xl mx-auto">
                     {[...primaryNavItems, ...secondaryNavItems].map((item, index) => (
-                      <motion.button
+                      <m.button
                         key={item.key}
                         onClick={() => {
                           navigateTo(item.sectionId);
@@ -403,13 +404,13 @@ const Navigation = () => {
                         transition={{ delay: 0.3 + index * 0.1, duration: 0.3 }}
                       >
                         {t(item.key)}
-                      </motion.button>
+                      </m.button>
                     ))}
                   </div>
                 </div>
-              </motion.div>
+              </m.div>
             </div>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
     </>

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import { Microscope, ExternalLink } from "lucide-react";
 
@@ -119,7 +119,7 @@ const ResearchSection = () => {
 
 
         {/* Publications */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={inView ? { opacity: 1 } : { opacity: 0 }}
           transition={{ delay: 0.3 }}
@@ -129,14 +129,14 @@ const ResearchSection = () => {
             {t("publications")}
           </h3>
           
-          <motion.div
+          <m.div
             variants={containerVariants}
             initial="hidden"
             animate={inView ? "visible" : "hidden"}
             className="space-y-6 max-w-4xl mx-auto"
           >
             {publications.map((pub, index) => (
-              <motion.div
+              <m.div
                 key={index}
                 variants={itemVariants}
                 className="bg-white dark:bg-slate-800 rounded-lg p-6 shadow-lg hover:shadow-xl transition-shadow"
@@ -193,11 +193,11 @@ const ResearchSection = () => {
                     )}
                   </div>
                 )}
-              </motion.div>
+              </m.div>
             ))}
-          </motion.div>
+          </m.div>
 
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );

--- a/src/components/TeachingSection.tsx
+++ b/src/components/TeachingSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import { GraduationCap, Users, Clock, Award, BookOpen, Target } from "lucide-react";
 
@@ -84,7 +84,7 @@ export default function TeachingSection() {
   return (
     <section id="teaching" className="py-20" ref={ref}>
       <div className="container mx-auto px-4">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: -20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: -20 }}
           transition={{ duration: 0.5 }}
@@ -96,10 +96,10 @@ export default function TeachingSection() {
           <p className="text-xl text-gray-600 dark:text-gray-400">
             {t("subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
         {/* JLPT Perfect Score Badge */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, scale: 0.8 }}
           animate={inView ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.8 }}
           transition={{ duration: 0.5, delay: 0.2 }}
@@ -119,17 +119,17 @@ export default function TeachingSection() {
               </p>
             </div>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Statistics */}
-        <motion.div
+        <m.div
           variants={containerVariants}
           initial="hidden"
           animate={inView ? "visible" : "hidden"}
           className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16"
         >
           {stats.map((stat, index) => (
-            <motion.div
+            <m.div
               key={index}
               variants={itemVariants}
               className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow"
@@ -143,12 +143,12 @@ export default function TeachingSection() {
               <div className="text-sm text-gray-600 dark:text-gray-400">
                 {stat.label}
               </div>
-            </motion.div>
+            </m.div>
           ))}
-        </motion.div>
+        </m.div>
 
         {/* Teaching Experience */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.5, delay: 0.3 }}
@@ -187,10 +187,10 @@ export default function TeachingSection() {
               </div>
             </div>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Courses */}
-        <motion.div
+        <m.div
           variants={containerVariants}
           initial="hidden"
           animate={inView ? "visible" : "hidden"}
@@ -200,7 +200,7 @@ export default function TeachingSection() {
           </h3>
           <div className="grid md:grid-cols-3 gap-6">
             {courses.map((course, index) => (
-              <motion.div
+              <m.div
                 key={index}
                 variants={itemVariants}
                 className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all hover:-translate-y-1"
@@ -225,13 +225,13 @@ export default function TeachingSection() {
                     </li>
                   ))}
                 </ul>
-              </motion.div>
+              </m.div>
             ))}
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Teaching Philosophy */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.5, delay: 0.5 }}
@@ -243,7 +243,7 @@ export default function TeachingSection() {
           <p className="text-lg text-gray-600 dark:text-gray-400 italic">
             &ldquo;{t("philosophyQuote")}&rdquo;
           </p>
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useRef } from "react";
 import {
   Baby,
@@ -109,7 +109,7 @@ const TimelineSection = () => {
             const yEnd = (index + 1) * totalSpacing + (cardHeight / 2);
             
             return (
-              <motion.svg
+              <m.svg
                 key={`flow-${index}`}
                 className="absolute w-full overflow-visible"
                 style={{ 
@@ -139,7 +139,7 @@ const TimelineSection = () => {
                 </defs>
                 
                 {/* Flowing path */}
-                <motion.path
+                <m.path
                   d={
                     isEven
                       ? nextIsEven
@@ -163,7 +163,7 @@ const TimelineSection = () => {
                 
                 {/* Flowing particles */}
                 {[...Array(3)].map((_, i) => (
-                  <motion.circle
+                  <m.circle
                     key={`particle-${index}-${i}`}
                     r="2"
                     fill={event.location === 'china' ? '#fbbf24' : '#60a5fa'}
@@ -183,9 +183,9 @@ const TimelineSection = () => {
                             : "M 600 10 Q 650 200, 600 390"
                       }
                     />
-                  </motion.circle>
+                  </m.circle>
                 ))}
-              </motion.svg>
+              </m.svg>
             );
           })}
         </div>
@@ -201,7 +201,7 @@ const TimelineSection = () => {
             const isKyotoEvent = event.title.includes("京都大学") || event.title.includes("修士") || event.title.includes("博士");
 
             return (
-              <motion.div
+              <m.div
                 key={index}
                 initial={{ opacity: 0, y: 50 }}
                 whileInView={{ opacity: 1, y: 0 }}
@@ -213,29 +213,29 @@ const TimelineSection = () => {
               >
                 {/* Plane animation for travel events */}
                 {isPlaneEvent && (
-                  <motion.div
+                  <m.div
                     className="absolute -top-16 left-1/2 transform -translate-x-1/2 z-20"
                     initial={{ x: event.location === "japan" ? -200 : 200, y: -50 }}
                     whileInView={{ x: 0, y: 0 }}
                     transition={{ duration: 1.5, type: "spring" }}
                   >
                     <div className="relative">
-                      <motion.div
+                      <m.div
                         animate={{ rotate: [0, 10, -10, 0] }}
                         transition={{ duration: 2, repeat: Infinity }}
                       >
                         <Plane className="text-blue-500 w-12 h-12" />
-                      </motion.div>
-                      <motion.div
+                      </m.div>
+                      <m.div
                         className="absolute -bottom-4 left-1/2 transform -translate-x-1/2"
                         initial={{ scale: 0 }}
                         animate={{ scale: [0, 1.5, 0] }}
                         transition={{ duration: 1.5, repeat: Infinity }}
                       >
                         <div className="w-2 h-2 bg-blue-400 rounded-full" />
-                      </motion.div>
+                      </m.div>
                     </div>
-                  </motion.div>
+                  </m.div>
                 )}
 
                 {/* Mobile timeline dot */}
@@ -255,7 +255,7 @@ const TimelineSection = () => {
                     : "left-0 right-1/2 transform origin-right"
                 }`} />
 
-                <motion.div
+                <m.div
                   className={`relative p-6 lg:p-8 rounded-2xl border-2 ${
                     isKyotoEvent 
                       ? "border-blue-300 dark:border-blue-700 shadow-2xl shadow-blue-200/50 dark:shadow-blue-900/50" 
@@ -283,13 +283,13 @@ const TimelineSection = () => {
 
                   <div className="flex items-start gap-4">
                     {/* Icon with unified design */}
-                    <motion.div 
+                    <m.div 
                       className={`p-3 bg-gradient-to-br ${getCountryColor(event.location)} rounded-xl shadow-lg`}
                       whileHover={{ scale: 1.05 }}
                       transition={{ type: "spring", stiffness: 300 }}
                     >
                       <Icon className="text-white" size={24} />
-                    </motion.div>
+                    </m.div>
 
                     <div className="flex-1">
                       {/* Year and location */}
@@ -321,8 +321,8 @@ const TimelineSection = () => {
 
                     </div>
                   </div>
-                </motion.div>
-              </motion.div>
+                </m.div>
+              </m.div>
             );
           })}
         </div>

--- a/src/components/URLShortenerSection.tsx
+++ b/src/components/URLShortenerSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { Link2, Copy, ExternalLink, Sparkles } from "lucide-react";
 
 const URLShortenerSection = () => {
@@ -67,7 +67,7 @@ const URLShortenerSection = () => {
   return (
     <section id="urlshortener" className="py-20 sm:py-24 lg:py-32">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -83,9 +83,9 @@ const URLShortenerSection = () => {
           <p className="text-lg text-slate-600 dark:text-slate-400">
             {t("subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
@@ -143,17 +143,17 @@ const URLShortenerSection = () => {
           </form>
 
           {error && (
-            <motion.div
+            <m.div
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
               className="mt-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
             >
               <p className="text-red-700 dark:text-red-300 text-sm">{error}</p>
-            </motion.div>
+            </m.div>
           )}
 
           {shortUrl && (
-            <motion.div
+            <m.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               className="mt-6 p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg"
@@ -190,11 +190,11 @@ const URLShortenerSection = () => {
                   {t("result.copied")}
                 </p>
               )}
-            </motion.div>
+            </m.div>
           )}
-        </motion.div>
+        </m.div>
 
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.4 }}
@@ -204,7 +204,7 @@ const URLShortenerSection = () => {
           <p className="mt-2 font-mono text-xs">
             link.ryosh.in • {t("footer.madeWith")} ❤️
           </p>
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );

--- a/src/components/YopmailAccessSection.tsx
+++ b/src/components/YopmailAccessSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { Mail, Copy, ExternalLink, Sparkles, ArrowRight, CheckCircle } from "lucide-react";
 
 const YopmailAccessSection = () => {
@@ -71,7 +71,7 @@ const YopmailAccessSection = () => {
   return (
     <section id="yopmail" className="py-20 sm:py-24 lg:py-32">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -87,9 +87,9 @@ const YopmailAccessSection = () => {
           <p className="text-lg text-slate-600 dark:text-slate-400">
             {t("subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
@@ -144,17 +144,17 @@ const YopmailAccessSection = () => {
           </form>
 
           {error && (
-            <motion.div
+            <m.div
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
               className="mt-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
             >
               <p className="text-red-700 dark:text-red-300 text-sm">{error}</p>
-            </motion.div>
+            </m.div>
           )}
 
           {shortUrl && (
-            <motion.div
+            <m.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               className="mt-6 p-6 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg"
@@ -211,10 +211,10 @@ const YopmailAccessSection = () => {
                   {t("result.copied")}
                 </p>
               )}
-            </motion.div>
+            </m.div>
           )}
 
-          <motion.div
+          <m.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.6, delay: 0.4 }}
@@ -229,10 +229,10 @@ const YopmailAccessSection = () => {
               <li>• {t("info.retention")}</li>
               <li>• {t("info.forwarding")}</li>
             </ul>
-          </motion.div>
-        </motion.div>
+          </m.div>
+        </m.div>
 
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.4 }}
@@ -242,7 +242,7 @@ const YopmailAccessSection = () => {
           <p className="mt-2 font-mono text-xs">
             Powered by Yopmail + link.ryosh.in • {t("footer.madeWith")} ❤️
           </p>
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );

--- a/src/components/ZennFeed.tsx
+++ b/src/components/ZennFeed.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { ExternalLink, Calendar, User, BookOpen } from "lucide-react";
 import Link from "next/link";
 
@@ -105,7 +105,7 @@ export default function ZennFeed() {
   return (
     <section id="blog" className="py-20 bg-gradient-to-b from-white to-slate-50 dark:from-slate-900 dark:to-slate-950">
       <div className="container mx-auto px-4">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
@@ -117,11 +117,11 @@ export default function ZennFeed() {
           <p className="text-xl text-gray-600 dark:text-gray-400">
             {t("subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
         {/* Featured Article */}
         {articles.length > 0 && (
-          <motion.div
+          <m.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.5, delay: 0.2 }}
@@ -168,18 +168,18 @@ export default function ZennFeed() {
                 </div>
               </div>
             </Link>
-          </motion.div>
+          </m.div>
         )}
 
         {/* Article Grid */}
-        <motion.div
+        <m.div
           variants={containerVariants}
           initial="hidden"
           animate="visible"
           className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12"
         >
           {articles.slice(1).map((article, index) => (
-            <motion.article
+            <m.article
               key={index}
               variants={itemVariants}
               className="group"
@@ -217,12 +217,12 @@ export default function ZennFeed() {
                   </div>
                 </div>
               </Link>
-            </motion.article>
+            </m.article>
           ))}
-        </motion.div>
+        </m.div>
 
         {/* View More Link */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.5 }}
@@ -237,7 +237,7 @@ export default function ZennFeed() {
             <span>{t("viewAllArticles")}</span>
             <ExternalLink size={18} />
           </Link>
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Create `MotionProvider` component wrapping app with `LazyMotion` + `domAnimation` (~5KB vs ~32KB full bundle)
- Replace `motion` imports with `m` across all 8 component files (Navigation, AboutSection, TimelineSection, ResearchSection, ZennFeed, URLShortenerSection, YopmailAccessSection, TeachingSection)
- Remove `layoutId="activeNavItem"` from Navigation (requires `domMax` which negates savings) and replace with simple opacity/scale animation

Closes #20

## Test plan
- [ ] Verify all page animations still work (scroll reveals, hover effects, nav transitions)
- [ ] Verify Navigation active section indicator animates smoothly
- [ ] Verify theme toggle animation works
- [ ] Verify language dropdown animation works  
- [ ] Verify mobile/desktop menu open/close animations work
- [ ] Check bundle size reduction in Vercel build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)