### PR TITLE
fix: replace generic blue-purple palette with teal-amber colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,27 +7,27 @@
 :root {
   --background: #fafafa;
   --foreground: #0a0a0a;
-  --primary: #3b82f6;
-  --primary-dark: #1d4ed8;
-  --secondary: #8b5cf6;
-  --accent: #06b6d4;
+  --primary: #0d9488;         /* teal-600 - distinctive, not generic blue */
+  --primary-dark: #0f766e;    /* teal-700 */
+  --secondary: #d97706;       /* amber-600 - warm accent */
+  --accent: #0891b2;          /* cyan-600 */
   --muted: #f1f5f9;
   --border: #e2e8f0;
-  --gradient-start: #667eea;
-  --gradient-end: #764ba2;
+  --gradient-start: #0d9488;  /* teal */
+  --gradient-end: #d97706;    /* amber */
 }
 
 :root.dark {
   --background: #020817;
   --foreground: #f8fafc;
-  --primary: #3b82f6;
-  --primary-dark: #1d4ed8;
-  --secondary: #8b5cf6;
-  --accent: #06b6d4;
+  --primary: #14b8a6;         /* teal-400 for dark mode */
+  --primary-dark: #0d9488;
+  --secondary: #f59e0b;       /* amber-400 */
+  --accent: #22d3ee;          /* cyan-300 */
   --muted: #1e293b;
   --border: #334155;
-  --gradient-start: #667eea;
-  --gradient-end: #764ba2;
+  --gradient-start: #14b8a6;
+  --gradient-end: #f59e0b;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- Replace the default AI-template color scheme (`#667eea` → `#764ba2` gradient, blue-500 primary) with a distinctive warm-toned palette
- Light mode: teal-600 primary (`#0d9488`), amber-600 secondary (`#d97706`), cyan-600 accent (`#0891b2`)
- Dark mode: teal-400 (`#14b8a6`), amber-400 (`#f59e0b`), cyan-300 (`#22d3ee`) for proper contrast

Closes #24

## Test plan
- [ ] Verify light mode colors render correctly (gradient-text, scrollbar, selection)
- [ ] Verify dark mode colors render correctly
- [ ] Check prefers-color-scheme media query still works
- [ ] Visual regression check on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)