### PR TITLE
Remove glassmorphism and glow effect CSS classes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,46 +92,12 @@ body {
   color: white;
 }
 
-/* Glassmorphism utility classes */
-.glass {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.glass-dark {
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  background: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
 /* Gradient text utility */
 .gradient-text {
   background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-}
-
-/* Modern shadow utilities */
-.shadow-glow {
-  box-shadow: 0 0 20px rgba(59, 130, 246, 0.15);
-}
-
-.shadow-glow-purple {
-  box-shadow: 0 0 20px rgba(139, 92, 246, 0.15);
-}
-
-/* Simplified animation utilities */
-@keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 15px rgba(59, 130, 246, 0.15); }
-  50% { box-shadow: 0 0 20px rgba(59, 130, 246, 0.25); }
-}
-
-.animate-pulse-glow {
-  animation: pulse-glow 3s ease-in-out infinite;
 }
 
 /* Container utility to ensure proper responsive behavior */


### PR DESCRIPTION
## Summary
- Removed `.glass`, `.glass-dark`, `.shadow-glow`, `.shadow-glow-purple`, and `.animate-pulse-glow` CSS utility classes from `globals.css`
- Removed the associated `@keyframes pulse-glow` animation
- These classes were AI-template design patterns not used by any components

## Test plan
- [ ] Verify the site renders correctly without the removed classes
- [ ] Confirm no visual regressions in light and dark modes

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)