### PR TITLE
fix: gradient-text 廃止、ソリッドカラーでタイポグラフィ階層構築

### DIFF
--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -88,7 +88,7 @@ const GallerySection = () => {
             <ImageIcon size={16} />
             {t("photoGallery")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -192,7 +192,7 @@ const HeroSection = () => {
 
           {/* Name */}
           <div className="mb-12">
-            <h1 className="text-3xl sm:text-5xl md:text-7xl lg:text-8xl font-black gradient-text mb-4 tracking-tight px-4">
+            <h1 className="text-3xl sm:text-5xl md:text-7xl lg:text-8xl font-black text-slate-900 dark:text-white mb-4 tracking-tight px-4">
               {names[currentNameIndex]}
             </h1>
           </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -374,7 +374,7 @@ const Navigation = () => {
                 <div className="hidden lg:block">
                   {/* Menu Title */}
                   <motion.h2
-                    className="text-3xl sm:text-4xl md:text-6xl font-black gradient-text mb-12 sm:mb-16"
+                    className="text-3xl sm:text-4xl md:text-6xl font-black text-slate-900 dark:text-white mb-12 sm:mb-16"
                     initial={{ y: 30, opacity: 0 }}
                     animate={{ y: 0, opacity: 1 }}
                     transition={{ delay: 0.2, duration: 0.4 }}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -173,7 +173,7 @@ const ProjectsSection = () => {
             <Rocket size={16} />
             {tBadges("featuredProjects")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -109,7 +109,7 @@ const ResearchSection = () => {
             <Microscope size={16} />
             {t("academicResearch")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -168,7 +168,7 @@ const SkillsSection = () => {
             <Zap size={16} />
             {t("technicalExpertise")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/URLShortenerSection.tsx
+++ b/src/components/URLShortenerSection.tsx
@@ -77,7 +77,7 @@ const URLShortenerSection = () => {
             <Sparkles size={16} />
             {t("badge")}
           </div>
-          <h1 className="text-4xl sm:text-5xl font-bold gradient-text mb-4">
+          <h1 className="text-4xl sm:text-5xl font-bold text-slate-900 dark:text-white mb-4">
             {t("title")}
           </h1>
           <p className="text-lg text-slate-600 dark:text-slate-400">

--- a/src/components/YopmailAccessSection.tsx
+++ b/src/components/YopmailAccessSection.tsx
@@ -81,7 +81,7 @@ const YopmailAccessSection = () => {
             <Sparkles size={16} />
             {t("badge")}
           </div>
-          <h1 className="text-4xl sm:text-5xl font-bold gradient-text mb-4">
+          <h1 className="text-4xl sm:text-5xl font-bold text-slate-900 dark:text-white mb-4">
             {t("title")}
           </h1>
           <p className="text-lg text-slate-600 dark:text-slate-400">


### PR DESCRIPTION
## Summary
- Replaced all `.gradient-text` class usage across 8 component files with `text-slate-900 dark:text-white`
- Affected components: HeroSection, Navigation, SkillsSection, ProjectsSection, ResearchSection, GallerySection, URLShortenerSection, YopmailAccessSection
- The `.gradient-text` CSS class definition is kept in `globals.css` for now (per issue instructions)

## Test plan
- [ ] Verify all section headings display in solid dark color (light mode) / white (dark mode)
- [ ] Confirm no remaining gradient-text usage in components
- [ ] Check both light and dark mode rendering

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)