### PR TITLE
Add Space Grotesk display font for typography personality

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, Noto_Sans_JP } from "next/font/google";
+import { Inter, Noto_Sans_JP, Space_Grotesk } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import Navigation from "@/components/Navigation";
@@ -13,6 +13,11 @@ const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "sw
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
   variable: "--font-noto-sans-jp",
+  display: "swap",
+});
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-display",
   display: "swap",
 });
 
@@ -129,7 +134,7 @@ export default async function RootLayout({
         </Script>
       </head>
       <body
-        className={`${inter.variable} ${notoSansJP.variable} font-sans antialiased bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 overflow-x-hidden w-full max-w-full`}
+        className={`${inter.variable} ${notoSansJP.variable} ${spaceGrotesk.variable} font-sans antialiased bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 overflow-x-hidden w-full max-w-full`}
         suppressHydrationWarning
         data-oid="1ogajcn"
       >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+
 
 /* Define dark variant for Tailwind v4 */
 @variant dark (&:is(:root.dark *));
@@ -33,7 +33,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
 


### PR DESCRIPTION
## Summary
- Add **Space Grotesk** as a distinctive geometric sans-serif display font (`--font-display` CSS variable) for future use in headings
- Remove redundant Google Fonts `@import` URL for Inter (next/font already handles loading)
- Add Noto Sans JP to the `--font-sans` stack for proper Japanese text fallback

Closes #29

## Test plan
- [ ] Verify the site loads without font-related errors
- [ ] Confirm Inter still applies as the default body font
- [ ] Check that `font-display` utility class is available in Tailwind for future heading use
- [ ] Verify no duplicate font loading (removed @import + next/font should not conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)