### PR TITLE
fix: diversify card designs across sections

### DIFF
--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -135,7 +135,7 @@ const GallerySection = () => {
               className="group cursor-pointer transition-transform duration-200 hover:-translate-y-2"
               onClick={() => openModal(index)}
             >
-              <div className="relative aspect-square overflow-hidden rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-200 border-4 border-white dark:border-slate-800">
+              <div className="relative aspect-square bg-white dark:bg-slate-900 rounded-xl overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-200">
                 <Image
                   src={image.src}
                   alt={image.alt}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -183,7 +183,7 @@ const ProjectsSection = () => {
 
         {/* Leadership Section */}
         <div className="mb-16">
-          <div className="max-w-4xl mx-auto bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl">
+          <div className="max-w-4xl mx-auto bg-white dark:bg-slate-800 rounded-2xl p-6 border-l-4 border-l-teal-500 shadow-md hover:shadow-lg transition-shadow duration-200">
             <div className="flex items-start gap-6">
               <div className="p-4 rounded-2xl bg-green-600 text-white shadow-lg">
                 <Users size={32} />
@@ -220,7 +220,7 @@ const ProjectsSection = () => {
             return (
               <div
                 key={index}
-                className="group relative overflow-hidden bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
+                className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-2xl p-6 border-l-4 border-l-teal-500 shadow-md hover:shadow-lg transition-shadow duration-200"
               >
                 {/* Background gradient overlay */}
                 <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -139,7 +139,7 @@ const ResearchSection = () => {
               <motion.div
                 key={index}
                 variants={itemVariants}
-                className="bg-white dark:bg-slate-800 rounded-lg p-6 shadow-lg hover:shadow-xl transition-shadow"
+                className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-6 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-colors duration-200"
               >
                 <div className="flex items-start justify-between flex-wrap gap-2">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex-1">

--- a/src/components/TeachingSection.tsx
+++ b/src/components/TeachingSection.tsx
@@ -132,7 +132,7 @@ export default function TeachingSection() {
             <motion.div
               key={index}
               variants={itemVariants}
-              className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow"
+              className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-750 transition-colors duration-200"
             >
               <div className={`bg-gradient-to-r ${stat.color} p-3 rounded-lg w-fit mb-4`}>
                 <stat.icon className="w-6 h-6 text-white" />
@@ -203,7 +203,7 @@ export default function TeachingSection() {
               <motion.div
                 key={index}
                 variants={itemVariants}
-                className="bg-white dark:bg-slate-800 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all hover:-translate-y-1"
+                className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-750 transition-colors duration-200"
               >
                 <div className="bg-gradient-to-r from-indigo-500 to-purple-500 p-3 rounded-lg w-fit mb-4">
                   <course.icon className="w-6 h-6 text-white" />


### PR DESCRIPTION
## Summary
- **ProjectsSection**: replaced uniform `bg-white/90 backdrop-blur-xl rounded-3xl shadow-xl` cards with left-colored border accent style (`border-l-4 border-l-teal-500`)
- **ResearchSection**: switched to minimal academic style with subtle `border-slate-200` and `hover:border-slate-300` transitions
- **GallerySection**: clean image-first grid items without heavy border/backdrop-blur
- **TeachingSection**: slim bordered cards with `hover:bg-slate-50` background transitions instead of shadow escalation

Closes #26

## Test plan
- [ ] Verify each section renders with its distinct card style in both light and dark mode
- [ ] Confirm hover states work correctly on all card types
- [ ] Check responsive layout is preserved on mobile/tablet/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)