### PR TITLE
fix: セクション構造の機械的均一性を解消

### DIFF
--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import { useTranslations } from "next-intl";
-import { X, ChevronLeft, ChevronRight, Camera, Image as ImageIcon, Filter } from "lucide-react";
+import { X, ChevronLeft, ChevronRight, Camera, Filter } from "lucide-react";
 import Image from "next/image";
 
 const GallerySection = () => {
@@ -80,15 +80,14 @@ const GallerySection = () => {
 
 
   return (
-    <section id="gallery" className="pt-32 pb-24 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
+    <section id="gallery" className="py-16 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 rounded-full text-sm font-medium mb-6">
-            <ImageIcon size={16} />
+          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
             {t("photoGallery")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-4xl md:text-5xl font-black gradient-text mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Smartphone, Globe, Brain, BookOpen, Rocket, Star, Users } from "lucide-react";
+import { Smartphone, Globe, Brain, BookOpen, Star, Users } from "lucide-react";
 import {
   SiReact as SiReactnative,
   SiSwift,
@@ -165,15 +165,14 @@ const ProjectsSection = () => {
   };
 
   return (
-    <section id="projects" className="pt-32 pb-24 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50">
+    <section id="projects" className="pt-24 pb-16 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm font-medium mb-6">
-            <Rocket size={16} />
+          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
             {tBadges("featuredProjects")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-4xl md:text-5xl lg:text-6xl font-black gradient-text mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { motion } from "framer-motion";
 import { useInView } from "react-intersection-observer";
-import { Microscope, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 type Publication = {
   authors: string;
@@ -101,15 +101,14 @@ const ResearchSection = () => {
   };
 
   return (
-    <section id="research" className="pt-32 pb-24 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50" ref={ref}>
+    <section id="research" className="pt-16 pb-20 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50" ref={ref}>
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 rounded-full text-sm font-medium mb-6">
-            <Microscope size={16} />
+          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
             {t("academicResearch")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-black gradient-text mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -9,7 +9,6 @@ import {
   Cloud,
   Brain,
   Globe,
-  Zap,
   TrendingUp,
   Award,
 } from "lucide-react";
@@ -160,15 +159,14 @@ const SkillsSection = () => {
   };
 
   return (
-    <section id="skills" className="pt-32 pb-24 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
+    <section id="skills" className="py-20 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
       <div className="container mx-auto px-6">
         {/* Header */}
         <div className="text-center mb-20">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-sm font-medium mb-6">
-            <Zap size={16} />
+          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
             {t("technicalExpertise")}
           </div>
-          <h2 className="text-5xl md:text-6xl lg:text-7xl font-black gradient-text mb-6 tracking-tight">
+          <h2 className="text-4xl md:text-5xl font-black gradient-text mb-6 tracking-tight">
             {t("title")}
           </h2>
           <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">

--- a/src/components/TeachingSection.tsx
+++ b/src/components/TeachingSection.tsx
@@ -82,7 +82,7 @@ export default function TeachingSection() {
   };
 
   return (
-    <section id="teaching" className="py-20" ref={ref}>
+    <section id="teaching" className="pt-20 pb-16" ref={ref}>
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
## Summary
- Replace identical pill-shaped badges (`inline-flex...rounded-full`) with simple uppercase overline text labels across all section headers
- Vary section padding so each section has distinct vertical rhythm (py-20, pt-24/pb-16, pt-16/pb-20, py-16, pt-20/pb-16)
- Scale down heading sizes from the uniform `text-5xl/6xl/7xl` to section-appropriate sizes
- Remove unused icon imports (Zap, Rocket, Microscope, ImageIcon)

## Test plan
- [ ] Verify each section renders correctly with no build errors
- [ ] Check that section spacing varies visually across the page
- [ ] Confirm badge labels display as simple overline text, not pill badges
- [ ] Verify dark mode still renders properly

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)