### PR TITLE
Phase 1 · PR 2: Hero editorial rewrite + RSC locale fix

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Fraunces, Instrument_Serif, JetBrains_Mono, Noto_Serif_JP } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getMessages, setRequestLocale } from "next-intl/server";
 import Navigation from "@/components/Navigation";
 import MotionProvider from "@/components/MotionProvider";
 import StructuredData from "@/components/StructuredData";
@@ -110,6 +110,7 @@ export default async function RootLayout({
   // Validate locale and provide default
   const validLocale =
     locale && ["ja", "en", "zh"].includes(locale) ? locale : "ja";
+  setRequestLocale(validLocale);
   const messages = await getMessages({ locale: validLocale });
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,6 +174,15 @@ h4, h5, h6 {
   border-radius: 2px;
 }
 
+/* Hero name display — locale-aware clamp.
+   CJK glyphs are wider per character, so ja/zh size down a step vs. en. */
+.name-display {
+  font-size: clamp(4rem, 13vw, 9rem);
+}
+:lang(en) .name-display {
+  font-size: clamp(4rem, 15vw, 11rem);
+}
+
 /* Hairline rules */
 hr, .rule {
   border: 0;

--- a/src/components/HeroQRTrigger.tsx
+++ b/src/components/HeroQRTrigger.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+
+type Props = {
+  platformId: "wechat" | "whatsapp";
+  label: string;
+  qrSrc: string;
+};
+
+const HeroQRTrigger = ({ platformId, label, qrSrc }: Props) => {
+  const [open, setOpen] = useState(false);
+  const tSocial = useTranslations("socialActions");
+  const tCommon = useTranslations("common");
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const dialogTitleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = triggerRef.current;
+    closeRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+      previouslyFocused?.focus();
+    };
+  }, [open]);
+
+  const dialogLabel =
+    platformId === "wechat" ? tSocial("wechatQR") : tSocial("whatsappQR");
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        className="inline-flex items-baseline gap-1 text-[color:var(--color-ink)] hover:text-[color:var(--color-teal-ink)] underline-offset-4 decoration-transparent hover:decoration-[color:var(--color-teal-ink)] underline transition-colors"
+      >
+        <span>{label}</span>
+        <span aria-hidden="true" className="meta">QR</span>
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={dialogTitleId}
+          className="fixed inset-0 z-50 flex items-center justify-center"
+        >
+          <button
+            type="button"
+            aria-label={tCommon("close")}
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+          />
+          <div className="relative z-10 bg-[color:var(--color-paper)] border border-[color:var(--color-rule)] p-8 max-w-sm w-[92vw] mx-4 shadow-none">
+            <h3 id={dialogTitleId} className="meta mb-6 text-[color:var(--color-ink)] opacity-100">
+              {dialogLabel}
+            </h3>
+            <Image
+              src={qrSrc}
+              alt={`${label} QR`}
+              width={256}
+              height={256}
+              sizes="256px"
+              className="w-full h-auto"
+            />
+            <button
+              ref={closeRef}
+              type="button"
+              onClick={() => setOpen(false)}
+              className="mt-6 w-full py-3 border border-[color:var(--color-rule)] text-[color:var(--color-ink)] hover:bg-[color:var(--color-paper-deep)] transition-colors text-sm font-medium"
+            >
+              {tCommon("close")}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default HeroQRTrigger;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,412 +1,226 @@
-"use client";
+import { getLocale, getTranslations } from "next-intl/server";
+import HeroQRTrigger from "./HeroQRTrigger";
 
-import { useState, useEffect } from "react";
-import { useTranslations, useLocale } from "next-intl";
-import { FaGithub, FaLinkedin, FaFacebook, FaInstagram, FaLine, FaWeixin, FaWhatsapp, FaEnvelope } from "react-icons/fa";
-import { SiQiita, SiX, SiXiaohongshu } from "react-icons/si";
-import Image from "next/image";
+type Category = "messaging" | "professional" | "social";
 
-const HeroSection = () => {
-  const [currentNameIndex, setCurrentNameIndex] = useState(0);
-  const [currentRoleIndex, setCurrentRoleIndex] = useState(0);
-  const [showWeChatQR, setShowWeChatQR] = useState(false);
-  const [showWhatsAppQR, setShowWhatsAppQR] = useState(false);
-  const t = useTranslations("hero");
-  const tNames = useTranslations("names");
-  const tCommon = useTranslations("common");
-  const tHeroCategories = useTranslations("heroCategories");
-  const tSocialActions = useTranslations("socialActions");
-  const tEmail = useTranslations("email");
-  const locale = useLocale();
+type Platform = {
+  id: string;
+  name: string;
+  href?: string;
+  qrCode?: string;
+  category: Category;
+  priority: { ja: number; en: number; zh: number };
+};
 
-  const names = [
-    tNames("japanese"),
-    tNames("japaneseFurigana"),
-    tNames("english"),
-    tNames("chinese")
-  ];
+const categoryOrderByLocale: Record<string, Category[]> = {
+  ja: ["professional", "messaging", "social"],
+  zh: ["messaging", "social", "professional"],
+  en: ["professional", "social", "messaging"],
+};
+
+const HeroSection = async () => {
+  const locale = (await getLocale()) as "ja" | "en" | "zh";
+  const t = await getTranslations("hero");
+  const tNames = await getTranslations("names");
+  const tEmail = await getTranslations("email");
+  const tHeroCategories = await getTranslations("heroCategories");
+
   const roles = t.raw("roles") as string[];
+  const role = roles[0] ?? "";
 
+  const primaryName =
+    locale === "en"
+      ? tNames("english")
+      : locale === "zh"
+        ? tNames("shortName")
+        : tNames("japanese");
 
-  // Social platforms with locale-based priorities
-  const socialPlatforms = [
+  const secondaryName =
+    locale === "en"
+      ? tNames("japanese")
+      : locale === "zh"
+        ? tNames("english")
+        : tNames("english");
+
+  const platforms: Platform[] = [
     {
-      id: 'email',
-      name: tEmail('contact'),
-      href: `mailto:${tEmail('address')}`,
-      icon: FaEnvelope,
-      color: 'slate',
+      id: "email",
+      name: tEmail("contact"),
+      href: `mailto:${tEmail("address")}`,
+      category: "professional",
       priority: { ja: 10, en: 10, zh: 10 },
-      category: 'professional'
     },
     {
-      id: 'github',
-      name: 'GitHub',
-      href: 'https://github.com/ryoshin0830',
-      icon: FaGithub,
-      color: 'slate',
+      id: "github",
+      name: "GitHub",
+      href: "https://github.com/ryoshin0830",
+      category: "professional",
       priority: { ja: 7, en: 8, zh: 7 },
-      category: 'professional'
     },
     {
-      id: 'linkedin',
-      name: 'LinkedIn',
-      href: 'https://www.linkedin.com/in/ryoshin',
-      icon: FaLinkedin,
-      color: 'blue',
-      priority: { ja: 8, en: 9, zh: 8 },
-      category: 'social'
-    },
-    {
-      id: 'x',
-      name: 'X',
-      href: 'https://x.com/ryoshin0830',
-      icon: SiX,
-      color: 'slate',
-      priority: { ja: 8, en: 7, zh: 6 },
-      category: 'social'
-    },
-    {
-      id: 'zenn',
-      name: 'Zenn',
-      href: 'https://zenn.dev/ryoushin',
-      iconPath: '/logo-only.svg',
-      color: 'sky',
+      id: "zenn",
+      name: "Zenn",
+      href: "https://zenn.dev/ryoushin",
+      category: "professional",
       priority: { ja: 9, en: 5, zh: 4 },
-      category: 'professional'
     },
     {
-      id: 'qiita',
-      name: 'Qiita',
-      href: 'https://qiita.com/ryoshin0830',
-      icon: SiQiita,
-      color: 'green',
+      id: "qiita",
+      name: "Qiita",
+      href: "https://qiita.com/ryoshin0830",
+      category: "professional",
       priority: { ja: 6, en: 4, zh: 3 },
-      category: 'professional'
     },
     {
-      id: 'line',
-      name: 'LINE',
-      href: 'https://line.me/ti/p/J7cd9CqhvX',
-      icon: FaLine,
-      color: 'green',
-      priority: { ja: 10, en: 3, zh: 5 },
-      category: 'messaging'
+      id: "linkedin",
+      name: "LinkedIn",
+      href: "https://www.linkedin.com/in/ryoshin",
+      category: "social",
+      priority: { ja: 8, en: 9, zh: 8 },
     },
     {
-      id: 'wechat',
-      name: 'WeChat',
-      href: '#',
-      icon: FaWeixin,
-      color: 'green',
-      priority: { ja: 4, en: 5, zh: 10 },
-      category: 'messaging',
-      qrCode: '/wechat-qr.png'
+      id: "x",
+      name: "X",
+      href: "https://x.com/ryoshin0830",
+      category: "social",
+      priority: { ja: 8, en: 7, zh: 6 },
     },
     {
-      id: 'whatsapp',
-      name: 'WhatsApp',
-      href: '#',
-      icon: FaWhatsapp,
-      color: 'green',
-      priority: { ja: 5, en: 9, zh: 4 },
-      category: 'messaging',
-      qrCode: '/whatsapp-qr.png'
-    },
-    {
-      id: 'facebook',
-      name: 'Facebook',
-      href: 'https://www.facebook.com/ryoshin0830',
-      icon: FaFacebook,
-      color: 'blue',
+      id: "facebook",
+      name: "Facebook",
+      href: "https://www.facebook.com/ryoshin0830",
+      category: "social",
       priority: { ja: 4, en: 6, zh: 5 },
-      category: 'social'
     },
     {
-      id: 'instagram',
-      name: 'Instagram',
-      href: 'https://www.instagram.com/ryoshin0830',
-      icon: FaInstagram,
-      color: 'pink',
+      id: "instagram",
+      name: "Instagram",
+      href: "https://www.instagram.com/ryoshin0830",
+      category: "social",
       priority: { ja: 5, en: 5, zh: 6 },
-      category: 'social'
     },
     {
-      id: 'xiaohongshu',
-      name: '小红书',
-      href: 'https://www.xiaohongshu.com/user/profile/5a0e90b211be1056202b808f?xsec_token=YBERRMVpcYr3fOe_IO5v-tr9JY5mUTiZ4O0J_11Q_DwII=&xsec_source=app_share&xhsshare=CopyLink&appuid=5a0e90b211be1056202b808f&apptime=1749915336&share_id=ba7caa0644c54d339241e3b501b3fede',
-      icon: SiXiaohongshu,
-      color: 'red',
+      id: "xiaohongshu",
+      name: "小红书",
+      href: "https://www.xiaohongshu.com/user/profile/5a0e90b211be1056202b808f?xsec_token=YBERRMVpcYr3fOe_IO5v-tr9JY5mUTiZ4O0J_11Q_DwII=&xsec_source=app_share&xhsshare=CopyLink&appuid=5a0e90b211be1056202b808f&apptime=1749915336&share_id=ba7caa0644c54d339241e3b501b3fede",
+      category: "social",
       priority: { ja: 2, en: 2, zh: 8 },
-      category: 'social'
-    }
+    },
+    {
+      id: "line",
+      name: "LINE",
+      href: "https://line.me/ti/p/J7cd9CqhvX",
+      category: "messaging",
+      priority: { ja: 10, en: 3, zh: 5 },
+    },
+    {
+      id: "wechat",
+      name: "WeChat",
+      qrCode: "/wechat-qr.png",
+      category: "messaging",
+      priority: { ja: 4, en: 5, zh: 10 },
+    },
+    {
+      id: "whatsapp",
+      name: "WhatsApp",
+      qrCode: "/whatsapp-qr.png",
+      category: "messaging",
+      priority: { ja: 5, en: 9, zh: 4 },
+    },
   ];
 
-  // Sort platforms based on current locale
-  const sortedPlatforms = [...socialPlatforms].sort((a, b) => {
-    const currentLocale = locale as 'ja' | 'en' | 'zh';
-    return (b.priority[currentLocale] || 0) - (a.priority[currentLocale] || 0);
-  });
+  const grouped = platforms.reduce((acc, p) => {
+    if (!acc[p.category]) acc[p.category] = [];
+    acc[p.category].push(p);
+    return acc;
+  }, {} as Record<Category, Platform[]>);
 
-  useEffect(() => {
-    const nameInterval = setInterval(() => {
-      setCurrentNameIndex((prev) => (prev + 1) % names.length);
-    }, 4000);
-    return () => clearInterval(nameInterval);
-  }, [names.length]);
+  for (const cat of Object.keys(grouped) as Category[]) {
+    grouped[cat].sort(
+      (a, b) => (b.priority[locale] ?? 0) - (a.priority[locale] ?? 0),
+    );
+  }
 
-  useEffect(() => {
-    const roleInterval = setInterval(() => {
-      setCurrentRoleIndex((prev) => (prev + 1) % roles.length);
-    }, 3500);
-    return () => clearInterval(roleInterval);
-  }, [roles.length]);
-
-  // Close QR codes when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      if (!target.closest('.qr-container')) {
-        setShowWeChatQR(false);
-        setShowWhatsAppQR(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  const categoryOrder = categoryOrderByLocale[locale] ?? categoryOrderByLocale.en;
 
   return (
-    <section id="hero" className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      {/* Modern gradient background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-slate-50 via-blue-50/50 to-purple-50/30 dark:from-slate-950 dark:via-blue-950/20 dark:to-purple-950/10" />
-      
-      {/* Minimal background elements */}
-      <div className="absolute inset-0 opacity-20 dark:opacity-10">
-        <div className="absolute top-20 right-20 w-64 h-64 bg-blue-400/10 rounded-full blur-2xl" />
-        <div className="absolute bottom-20 left-20 w-80 h-80 bg-purple-400/10 rounded-full blur-2xl" />
-      </div>
-
-      <div className="container mx-auto px-4 sm:px-6 relative z-10 w-full max-w-7xl">
-        <div className="text-center max-w-5xl mx-auto pt-32 pb-16">
-
-          {/* Name */}
-          <div className="mb-12">
-            <h1 className="text-3xl sm:text-5xl md:text-7xl lg:text-8xl font-black text-slate-900 dark:text-white mb-4 tracking-tight px-4">
-              {names[currentNameIndex]}
-            </h1>
-          </div>
-
-          {/* Role */}
-          <div className="mb-12 px-4">
-            <div className="flex items-center justify-center gap-4 sm:gap-8 mb-6">
-              <div className="h-px bg-gradient-to-r from-transparent via-blue-500/50 to-transparent flex-1 max-w-16 sm:max-w-32" />
-              <div className="relative px-4 sm:px-8 py-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-full border border-blue-200/50 dark:border-blue-700/50">
-                <span className="text-sm sm:text-xl md:text-2xl font-bold text-blue-600 dark:text-blue-400">
-                  {roles[currentRoleIndex]}
-                </span>
-              </div>
-              <div className="h-px bg-gradient-to-r from-transparent via-blue-500/50 to-transparent flex-1 max-w-16 sm:max-w-32" />
-            </div>
-          </div>
-
-          {/* Subtitle */}
-          <h2 className="text-xl sm:text-2xl md:text-3xl lg:text-4xl text-slate-700 dark:text-slate-300 mb-6 font-light tracking-wide px-4">
-            {t("subtitle")}
-          </h2>
-
-          {/* Description */}
-          <p className="text-base sm:text-lg md:text-xl text-slate-600 dark:text-slate-400 mb-8 max-w-3xl mx-auto leading-relaxed px-4">
-            {t("description")}
+    <section
+      id="hero"
+      className="relative min-h-screen flex items-end bg-[color:var(--color-paper)] pt-28 pb-16 sm:pb-20"
+    >
+      <div className="container mx-auto px-6 sm:px-10 max-w-7xl w-full relative z-10">
+        <div className="max-w-4xl">
+          <p className="meta mb-6 sm:mb-10">
+            <span>{t("kyoto")}</span>
+            <span aria-hidden="true" className="mx-2 opacity-60">·</span>
+            <span>{new Date().getFullYear()}</span>
           </p>
 
-          {/* Personal Details */}
-          <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4 mb-8 text-xs sm:text-sm md:text-base text-slate-600 dark:text-slate-400 px-4">
-            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm rounded-full border border-slate-200/30 dark:border-slate-700/30">
-              <span className="font-semibold">{t("origin")}</span>
-              <span className="text-slate-700 dark:text-slate-300">{t("beijing")}</span>
-            </div>
-            <div className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm rounded-full border border-slate-200/30 dark:border-slate-700/30">
-              <span className="font-semibold">{t("current")}</span>
-              <span className="text-slate-700 dark:text-slate-300">{t("kyoto")}</span>
-            </div>
+          <h1
+            className="font-display text-[color:var(--color-ink)] tracking-[-0.035em] leading-[0.9] name-display"
+            lang={locale === "en" ? "en" : locale === "zh" ? "zh" : "ja"}
+          >
+            {primaryName}
+          </h1>
+
+          <p className="meta mt-5 sm:mt-6">
+            <span className="text-[color:var(--color-ink)]">{role}</span>
+            <span aria-hidden="true" className="mx-2 opacity-60">·</span>
+            <span>{secondaryName}</span>
+          </p>
+
+          <div className="mt-12 sm:mt-16 max-w-2xl space-y-3">
+            <p className="text-lg sm:text-xl leading-[1.55] text-[color:var(--color-ink)]">
+              {t("subtitle")}
+            </p>
+            <p className="meta">
+              {t("description")}
+            </p>
+            <p className="meta text-[color:var(--color-ink-soft)]">
+              <span>{t("beijing")}</span>
+              <span aria-hidden="true" className="mx-2">→</span>
+              <span>{t("kyoto")}</span>
+            </p>
           </div>
 
-          {/* Social Links Section */}
-          <div className="mt-12 mb-20 px-4">
-            <div className="flex flex-col items-center justify-center">
-              {/* Elegant divider */}
-              <div className="w-24 h-px bg-gradient-to-r from-transparent via-slate-400 dark:via-slate-600 to-transparent mb-10" />
-              
-              {/* Social Links - Clean Layout */}
-              <div className="flex flex-wrap justify-center items-start gap-6 sm:gap-10 max-w-4xl mx-auto">
-              {/* Group platforms by category */}
-              {(() => {
-                const grouped = sortedPlatforms.reduce((acc, platform) => {
-                  const category = platform.category;
-                  if (!acc[category]) acc[category] = [];
-                  acc[category].push(platform);
-                  return acc;
-                }, {} as Record<string, typeof sortedPlatforms>);
+          <hr className="rule-soft mt-16 sm:mt-20 max-w-2xl" />
 
-                // Define category order and names based on locale
-                const categoryConfig = {
-                  ja: {
-                    order: ['messaging', 'professional', 'social'],
-                    names: { 
-                      messaging: tHeroCategories('messaging'), 
-                      professional: tHeroCategories('professional'), 
-                      social: tHeroCategories('social') 
-                    }
-                  },
-                  zh: {
-                    order: ['messaging', 'social', 'professional'],
-                    names: { 
-                      messaging: tHeroCategories('messaging'), 
-                      professional: tHeroCategories('professional'), 
-                      social: tHeroCategories('social') 
-                    }
-                  },
-                  en: {
-                    order: ['professional', 'social', 'messaging'],
-                    names: { 
-                      messaging: tHeroCategories('messaging'), 
-                      professional: tHeroCategories('professional'), 
-                      social: tHeroCategories('social') 
-                    }
-                  }
-                };
-
-                const config = categoryConfig[locale as keyof typeof categoryConfig] || categoryConfig.en;
-
-                return config.order.map((category) => {
-                  const platforms = grouped[category] || [];
-                  if (platforms.length === 0) return null;
-
-                  return (
-                    <div key={category} className="flex flex-col items-center min-w-0 w-auto">
-                      {/* Category name - smaller and more subtle */}
-                      <h4 className={`text-xs font-medium mb-2 opacity-60 ${
-                        category === 'professional' ? 'text-slate-700 dark:text-slate-400' :
-                        category === 'social' ? 'text-slate-700 dark:text-slate-400' :
-                        'text-slate-700 dark:text-slate-400'
-                      }`}>
-                        {config.names[category as keyof typeof config.names]}
-                      </h4>
-                      
-                      {/* Platforms in this category */}
-                      <div className="flex flex-wrap justify-center gap-2 max-w-none">
-                        {platforms.map((platform) => {
-                          const isQRPlatform = platform.qrCode !== undefined;
-                          
-                          // Define color classes
-                          const colorClasses = {
-                            slate: 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700',
-                            sky: 'bg-sky-50 dark:bg-sky-950 text-sky-700 dark:text-sky-300 border-sky-200 dark:border-sky-800',
-                            green: 'bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800',
-                            blue: 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800',
-                            pink: 'bg-pink-50 dark:bg-pink-950 text-pink-700 dark:text-pink-300 border-pink-200 dark:border-pink-800',
-                            red: 'bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800'
-                          };
-                          
-                          if (isQRPlatform) {
-                            return (
-                              <div
-                                key={platform.id}
-                                className="relative"
-                              >
-                                <button
-                                  onClick={() => platform.id === 'wechat' ? setShowWeChatQR(!showWeChatQR) : setShowWhatsAppQR(!showWhatsAppQR)}
-                                  className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:scale-105`}
-                                >
-                                  <div
-                                    className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                                    style={{
-                                      background: platform.color === 'green' 
-                                        ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)' 
-                                        : 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)'
-                                    }}
-                                  />
-                                  {platform.icon && <platform.icon size={16} className="sm:w-6 sm:h-6 relative z-10 group-hover:text-white transition-colors duration-300" />}
-                                </button>
-                                {((platform.id === 'wechat' && showWeChatQR) || (platform.id === 'whatsapp' && showWhatsAppQR)) && (
-                                  <>
-                                    {/* Backdrop */}
-                                    <div
-                                      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
-                                      onClick={() => platform.id === 'wechat' ? setShowWeChatQR(false) : setShowWhatsAppQR(false)}
-                                    />
-                                    {/* Modal */}
-                                    <div
-                                      className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-4 sm:p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-2xl z-50 max-w-sm mx-4"
-                                    >
-                                      <h3 className="text-lg sm:text-xl font-semibold text-slate-800 dark:text-slate-200 mb-4 sm:mb-6 text-center">
-                                        {platform.id === 'wechat' ? tSocialActions('wechatQR') : tSocialActions('whatsappQR')}
-                                      </h3>
-                                      <div className="bg-white p-2 sm:p-4 rounded-xl">
-                                        <Image
-                                          src={platform.qrCode}
-                                          alt={`${platform.name} QR Code`}
-                                          width={200}
-                                          height={200}
-                                          sizes="240px"
-                                          className="rounded-lg w-full max-w-60 mx-auto"
-                                        />
-                                      </div>
-                                      <button
-                                        onClick={() => platform.id === 'wechat' ? setShowWeChatQR(false) : setShowWhatsAppQR(false)}
-                                        className="mt-4 sm:mt-6 w-full px-4 sm:px-6 py-2 sm:py-3 bg-slate-100 dark:bg-slate-700 rounded-xl text-slate-700 dark:text-slate-300 font-medium hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors text-sm sm:text-base"
-                                      >
-                                        {tCommon('close')}
-                                      </button>
-                                    </div>
-                                  </>
-                                )}
-                              </div>
-                            );
-                          }
-
-                          return (
-                            <a
-                              key={platform.id}
-                              href={platform.href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className={`relative p-2.5 sm:p-3 ${colorClasses[platform.color as keyof typeof colorClasses]} rounded-lg shadow-sm hover:shadow-md transition-all duration-200 group border hover:scale-105`}
-                            >
-                              <div
-                                className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                                style={{
-                                  background: platform.color === 'slate' ? 'linear-gradient(135deg, #475569 0%, #1e293b 100%)' 
-                                    : platform.color === 'green' ? 'linear-gradient(135deg, #10b981 0%, #059669 100%)' 
-                                    : platform.color === 'blue' ? 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)' 
-                                    : platform.color === 'pink' ? 'linear-gradient(135deg, #ec4899 0%, #a855f7 100%)' 
-                                    : platform.color === 'red' ? 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)'
-                                    : 'linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%)'
-                                }}
-                              />
-                              {platform.icon ? (
-                                <platform.icon size={18} className="sm:w-5 sm:h-5 relative z-10 group-hover:text-white transition-colors duration-200" />
-                              ) : (
-                                <Image
-                                  src={platform.iconPath!}
-                                  alt={platform.name}
-                                  width={16}
-                                  height={16}
-                                  sizes="20px"
-                                  className="relative z-10 w-4.5 h-4.5 sm:w-5 sm:h-5"
-                                />
-                              )}
-                            </a>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                }).filter(Boolean);
-              })()}
-            </div>
-            </div>
+          <div className="mt-10 grid gap-10 sm:grid-cols-3 max-w-3xl">
+            {categoryOrder.map((category) => {
+              const items = grouped[category] ?? [];
+              if (items.length === 0) return null;
+              return (
+                <div key={category}>
+                  <h2 className="meta mb-4">
+                    {tHeroCategories(category)}
+                  </h2>
+                  <ul className="space-y-2 text-[color:var(--color-ink)]">
+                    {items.map((p) =>
+                      p.qrCode ? (
+                        <li key={p.id}>
+                          <HeroQRTrigger
+                            platformId={p.id as "wechat" | "whatsapp"}
+                            label={p.name}
+                            qrSrc={p.qrCode}
+                          />
+                        </li>
+                      ) : (
+                        <li key={p.id}>
+                          <a
+                            href={p.href}
+                            target={p.href?.startsWith("http") ? "_blank" : undefined}
+                            rel={p.href?.startsWith("http") ? "noopener noreferrer" : undefined}
+                            className="underline-offset-4 decoration-transparent hover:decoration-[color:var(--color-teal-ink)] hover:text-[color:var(--color-teal-ink)] underline transition-colors"
+                          >
+                            {p.name}
+                          </a>
+                        </li>
+                      ),
+                    )}
+                  </ul>
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -175,56 +175,42 @@ const Navigation = () => {
           <div className="hidden lg:flex items-center gap-1 xl:gap-2">
             {/* Primary Navigation Items */}
             {primaryNavItems.map((item) => (
-              <m.div
+              <button
                 key={item.key}
-                className="relative"
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
+                type="button"
+                onClick={() => navigateTo(item.sectionId)}
+                className={`px-3 py-2 text-sm transition-colors ${
+                  activeSection === item.sectionId
+                    ? "text-[color:var(--color-ink)] underline underline-offset-4 decoration-[color:var(--color-teal-ink)] decoration-2"
+                    : "text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)]"
+                }`}
               >
-                {activeSection === item.sectionId && (
-                  <m.div
-                    className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full"
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ duration: 0.2 }}
-                  />
-                )}
-                <button
-                  className={`relative z-10 px-2 lg:px-3 xl:px-4 py-1.5 lg:py-2 xl:py-2.5 rounded-full font-medium text-xs lg:text-sm transition-all duration-300 ${
-                    activeSection === item.sectionId
-                      ? "text-white"
-                      : "text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400"
-                  }`}
-                  onClick={() => navigateTo(item.sectionId)}
-                >
-                  {t(item.key)}
-                </button>
-              </m.div>
+                {t(item.key)}
+              </button>
             ))}
 
             {/* Hamburger Menu Button */}
-            <m.button
+            <button
+              type="button"
               onClick={() => setShowMoreMenu(!showMoreMenu)}
-              className={`p-2 lg:p-3 rounded-full transition-all duration-300 ${
+              aria-label="Menu"
+              className={`p-2 lg:p-3 transition-colors ${
                 secondaryNavItems.some(item => activeSection === item.sectionId)
-                  ? "bg-gradient-to-r from-blue-600 to-purple-600 text-white"
-                  : "text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-slate-100 dark:hover:bg-slate-800"
+                  ? "text-[color:var(--color-teal-ink)]"
+                  : "text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)]"
               }`}
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
             >
               <Menu size={16} className="lg:w-5 lg:h-5" />
-            </m.button>
+            </button>
           </div>
 
           {/* Right Side Controls */}
           <div className="flex items-center gap-1 sm:gap-2 lg:gap-3">
             {/* Theme Toggle */}
-            <m.button
+            <button
+              type="button"
               onClick={toggleTheme}
-              className="p-1.5 sm:p-2 lg:p-2.5 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
+              className="p-1.5 sm:p-2 lg:p-2.5 text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] transition-colors"
               aria-label="Toggle dark mode"
             >
               {mounted ? (
@@ -254,49 +240,52 @@ const Navigation = () => {
               ) : (
                 <div className="w-[14px] h-[14px] sm:w-[18px] sm:h-[18px] lg:w-5 lg:h-5" />
               )}
-            </m.button>
+            </button>
 
             {/* Language Selector */}
             <div className="relative language-menu">
-              <m.button
+              <button
+                type="button"
                 onClick={() => setShowLangMenu(!showLangMenu)}
-                className="flex items-center gap-1 sm:gap-2 px-1.5 sm:px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
+                aria-haspopup="menu"
+                aria-expanded={showLangMenu}
+                className="flex items-center gap-1 sm:gap-2 px-2 lg:px-3 py-1.5 sm:py-2 lg:py-2.5 border border-[color:var(--color-rule-soft)] text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] hover:border-[color:var(--color-rule)] transition-colors"
               >
                 <span className="text-sm sm:text-base lg:text-lg">
                   {languages.find(lang => lang.code === locale)?.flag || "🌍"}
                 </span>
-                <span className="hidden sm:block text-xs lg:text-sm font-medium truncate max-w-16 lg:max-w-none">
+                <span className="hidden sm:block text-xs lg:text-sm truncate max-w-16 lg:max-w-none">
                   {languages.find(lang => lang.code === locale)?.name || locale.toUpperCase()}
                 </span>
-              </m.button>
+              </button>
 
               <AnimatePresence>
                 {showLangMenu && (
                   <m.div
-                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-white dark:bg-slate-800 rounded-2xl shadow-2xl border border-slate-200/50 dark:border-slate-700/50"
-                    initial={{ opacity: 0, y: -10, scale: 0.95 }}
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    exit={{ opacity: 0, y: -10, scale: 0.95 }}
-                    transition={{ duration: 0.2 }}
+                    role="menu"
+                    className="absolute top-full right-0 mt-2 py-2 w-32 sm:w-40 lg:w-48 bg-[color:var(--color-paper)] border border-[color:var(--color-rule-soft)]"
+                    initial={{ opacity: 0, y: -8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -8 }}
+                    transition={{ duration: 0.15 }}
                   >
                     {languages.map((language) => (
-                      <m.button
+                      <button
                         key={language.code}
+                        role="menuitem"
+                        type="button"
                         onClick={() => handleLanguageChange(language.code)}
-                        className={`w-full text-left px-3 lg:px-4 py-2 lg:py-3 text-xs lg:text-sm font-medium transition-all duration-200 ${
+                        className={`w-full text-left px-3 lg:px-4 py-2 lg:py-3 text-xs lg:text-sm transition-colors ${
                           locale === language.code
-                            ? "bg-blue-50 dark:bg-blue-950/50 text-blue-600 dark:text-blue-400"
-                            : "text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50"
+                            ? "text-[color:var(--color-teal-ink)]"
+                            : "text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] hover:bg-[color:var(--color-paper-deep)]"
                         }`}
-                        whileHover={{ x: 4 }}
                       >
                         <span className="flex items-center gap-2 lg:gap-3">
                           <span className="text-sm lg:text-lg">{language.flag}</span>
                           <span className="truncate">{language.name}</span>
                         </span>
-                      </m.button>
+                      </button>
                     ))}
                   </m.div>
                 )}
@@ -304,14 +293,14 @@ const Navigation = () => {
             </div>
 
             {/* Mobile Menu Button */}
-            <m.button
+            <button
+              type="button"
               onClick={() => setShowMoreMenu(!showMoreMenu)}
-              className="lg:hidden p-1.5 sm:p-2 rounded-full bg-white dark:bg-slate-800 border border-slate-200/50 dark:border-slate-700/50 text-slate-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300 shadow-lg hover:shadow-xl"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
+              aria-label="Menu"
+              className="lg:hidden p-1.5 sm:p-2 text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] transition-colors"
             >
               <Menu size={14} className="sm:w-[18px] sm:h-[18px]" />
-            </m.button>
+            </button>
           </div>
         </div>
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,11 +1,11 @@
 import { getRequestConfig } from 'next-intl/server';
 
-export default getRequestConfig(async ({ locale }) => {
-  // Validate and default locale
-  const validLocale = locale && ['ja', 'en', 'zh'].includes(locale) ? locale : 'ja';
-  
+export default getRequestConfig(async ({ requestLocale }) => {
+  const requested = await requestLocale;
+  const locale = requested && ['ja', 'en', 'zh'].includes(requested) ? requested : 'ja';
+
   return {
-    locale: validLocale,
-    messages: (await import(`../messages/${validLocale}.json`)).default
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default
   };
 });


### PR DESCRIPTION
_Stacked on top of PR #52._

## Summary
- Replace the centered-template Hero (rotating name/role, gradient blobs, colored pill badges, social tiles) with a left-aligned editorial layout: single localized name, serif display, mono meta, plaintext social lists with teal underline hover.
- Split QR modal logic into a tiny client leaf (`HeroQRTrigger`) with proper dialog semantics (role="dialog", aria-modal, Escape to close, focus restore, body-scroll lock). Remove all other client code from the Hero.
- Clean up the Navigation bar to match: teal-underline active state instead of the blue/purple gradient pill, no scale/shadow hover, editorial hairline language dropdown, real `aria-label` on icon-only buttons.
- Fix a latent locale bug exposed by the PR 1 RSC migration: `getTranslations` in Server Components was falling back to `ja` on `/en` and `/zh`. Add `setRequestLocale` in the root layout and migrate `i18n.ts` to the next-intl v4 `requestLocale` contract.

## Why
Codex audit flagged the Hero's rotation + centered template as the loudest template signal on the page, and noted that `@theme inline` tokens were never applied in components. This PR is the first place the editorial tokens (`bg-paper`, `text-ink`, `.meta`, `.rule-soft`, `font-display`) actually show up on a page.

## Test plan
- [x] `npm run build` clean; `/[locale]` payload 18.9 kB → **11.4 kB**, First Load JS 147 → **139 kB**.
- [x] `npm run start` on `/ja`, `/en`, `/zh`: correct per-locale name, role, subtitle — no more fallback to ja.
- [x] `document.querySelectorAll('h1').length === 1`, `mainCount === 1`.
- [x] No `linear-gradient`, no `border-radius ≥ 8px`, no `box-shadow ≠ none` inside `#hero`.
- [ ] Reviewer: keyboard tab — QR button → modal opens → Escape closes → focus returns.
- [ ] Reviewer: dark mode toggle still works; reduced-motion respected.
- [ ] Reviewer: visual diff on all three locales (screenshots in the PR body would help).

🤖 Generated with [Claude Code](https://claude.com/claude-code)