### PR TITLE
Phase 1 · PR 3: Sections editorial rebuild

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,113 +1,55 @@
-import { getTranslations } from "next-intl/server";
-import {
-  Briefcase,
-  Users,
-  Sparkles,
-  University,
-} from "lucide-react";
+import { getLocale, getTranslations } from "next-intl/server";
 import TimelineSection from "./TimelineSection";
 
 const AboutSection = async () => {
+  const locale = await getLocale();
   const t = await getTranslations("about");
-  const badgesT = await getTranslations("badges");
   const skillsT = await getTranslations("skills");
 
   const fields = t.raw("fields") as string[];
+  const isLatin = locale === "en";
 
   return (
-    <section id="about" className="pt-32 pb-24 bg-gradient-to-b from-white to-slate-50/50 dark:from-slate-950 dark:to-slate-900/50 overflow-hidden">
-      <div className="container mx-auto px-4 sm:px-6 max-w-7xl">
-        {/* Header */}
-        <div className="text-center mb-16 sm:mb-20">
-          <div className="inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-slate-100 dark:bg-slate-800/50 text-slate-700 dark:text-slate-300 rounded-full text-xs sm:text-sm font-medium mb-4 sm:mb-6">
-            <Sparkles size={14} className="sm:w-4 sm:h-4" />
-            {badgesT("aboutMe")}
-          </div>
-          <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 text-slate-900 dark:text-white px-4">
-            {t("title")}
-          </h2>
-          <p className="text-base sm:text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto px-4">
+    <section id="about" className="py-24 bg-[color:var(--color-paper)]">
+      <div className="container mx-auto px-6 sm:px-10 max-w-5xl">
+        <header className="mb-12">
+          <p className="meta mb-3">{t("title")}</p>
+        </header>
+
+        <div className="max-w-3xl">
+          <p
+            className={`${isLatin ? "dropcap" : ""} text-lg sm:text-xl leading-[1.75] text-[color:var(--color-ink)]`}
+          >
             {t("subtitle")}
           </p>
         </div>
 
-        {/* Main Content Grid */}
-        <div className="max-w-6xl mx-auto">
-          {/* Current Status Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6 mb-12 sm:mb-16">
-            <div className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300">
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-blue-500/10 to-purple-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
-              <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <University className="text-white" size={20} />
-                </div>
-                <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
-                  {t("education")}
-                </h3>
-                <p className="text-slate-700 dark:text-slate-200 font-medium mb-1 text-sm sm:text-base">
-                  {t("kyotoUniversity")}
-                </p>
-                <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
-                  {skillsT("jobTitle")}
-                </p>
-              </div>
-            </div>
+        <dl className="mt-16 grid gap-6 sm:grid-cols-[10rem_1fr] sm:gap-10 divide-y sm:divide-y-0 divide-[color:var(--color-rule-soft)]">
+          <dt className="meta pt-6 sm:pt-0">{t("education")}</dt>
+          <dd className="pt-2 sm:pt-0">
+            <p className="text-lg text-[color:var(--color-ink)]">
+              {t("kyotoUniversity")}
+            </p>
+            <p className="meta mt-1 opacity-80">{skillsT("jobTitle")}</p>
+          </dd>
 
-            <div className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300">
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-purple-500/10 to-pink-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
-              <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <Briefcase className="text-white" size={20} />
-                </div>
-                <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
-                  {t("experience")}
-                </h3>
-              </div>
-            </div>
+          <dt className="meta pt-6 sm:pt-0">{t("teaching")}</dt>
+          <dd className="pt-2 sm:pt-0">
+            <p className="text-lg text-[color:var(--color-ink)]">
+              {t("japaneseTeacher")}
+            </p>
+            <p className="meta mt-1 opacity-80">
+              {skillsT("yearsExperience", { years: "7" })}
+            </p>
+          </dd>
 
-            <div className="group relative overflow-hidden bg-white dark:bg-slate-800/50 rounded-2xl p-6 sm:p-8 border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300">
-              <div className="absolute top-0 right-0 w-24 sm:w-32 h-24 sm:h-32 bg-gradient-to-br from-emerald-500/10 to-teal-500/10 rounded-full blur-3xl group-hover:scale-150 transition-transform duration-500" />
-              <div className="relative">
-                <div className="inline-flex p-2 sm:p-3 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-xl shadow-lg mb-3 sm:mb-4">
-                  <Users className="text-white" size={20} />
-                </div>
-                <h3 className="font-bold text-lg sm:text-xl text-slate-900 dark:text-white mb-2">
-                  {t("teaching")}
-                </h3>
-                <p className="text-slate-700 dark:text-slate-200 font-medium mb-1 text-sm sm:text-base">
-                  {t("japaneseTeacher")}
-                </p>
-                <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
-                  {skillsT("yearsExperience", { years: "7" })}
-                </p>
-              </div>
-            </div>
-          </div>
+          <dt className="meta pt-6 sm:pt-0">{t("specialization")}</dt>
+          <dd className="pt-2 sm:pt-0 text-[color:var(--color-ink)] leading-relaxed">
+            {fields.join(" · ")}
+          </dd>
+        </dl>
 
-          {/* Specialization Fields */}
-          <div className="mb-12 sm:mb-16">
-            <h3 className="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white mb-6 sm:mb-8 text-center px-4">
-              {t("specialization")}
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
-              {fields.map((field, index) => (
-                <div
-                  key={index}
-                  className="group flex items-center gap-3 sm:gap-4 p-3 sm:p-4 bg-white dark:bg-slate-800/30 rounded-xl border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300"
-                >
-                  <div className="flex-shrink-0 w-2 h-2 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full" />
-                  <p className="text-slate-700 dark:text-slate-300 font-medium text-sm sm:text-base">
-                    {field}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-
-          {/* Timeline Section */}
-          <TimelineSection />
-        </div>
+        <TimelineSection />
       </div>
     </section>
   );

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,304 +1,138 @@
 import { getTranslations } from "next-intl/server";
-import { Smartphone, Globe, Brain, BookOpen, Star, Users } from "lucide-react";
-import {
-  SiReact as SiReactnative,
-  SiSwift,
-  SiNextdotjs,
-  SiAwsamplify as SiAws,
-  SiMongodb,
-  SiPython,
-  SiTensorflow,
-  SiNodedotjs,
-  SiVercel,
-  SiGooglecloud,
-  SiNginx,
-  SiMariadb,
-  SiPostgresql,
-  SiTypescript,
-  SiTailwindcss,
-} from "react-icons/si";
+
+type ProjectStatus = "ongoing" | "active" | "completed";
+
+type ProjectMeta = {
+  id: string;
+  status: ProjectStatus;
+  period: { startYear: string; endYear?: string };
+};
+
+const projectMeta: ProjectMeta[] = [
+  { id: "sokudoku-gorilla", status: "ongoing", period: { startYear: "2025" } },
+  { id: "nichiu-nichigo", status: "completed", period: { startYear: "2022", endYear: "2023" } },
+  { id: "matsunoha", status: "active", period: { startYear: "2023", endYear: "2024" } },
+  { id: "lands-english", status: "completed", period: { startYear: "2021", endYear: "2022" } },
+  { id: "llm-research", status: "ongoing", period: { startYear: "2023" } },
+  { id: "llm-vocab-difficulty", status: "active", period: { startYear: "2024" } },
+  { id: "edu-llm", status: "ongoing", period: { startYear: "2024" } },
+  { id: "vocab-question-gen", status: "active", period: { startYear: "2024" } },
+];
 
 const ProjectsSection = async () => {
   const t = await getTranslations("projects");
-  const tBadges = await getTranslations("badges");
-  const tStatus = await getTranslations("status");
   const tDates = await getTranslations("dates");
+  const tStatus = await getTranslations("status");
 
-  // Get projects from translations
   const projectsList = t.raw("projectsList") as Array<{
     title: string;
     description: string;
     technologies: string[];
     features: string[];
   }>;
-  
-  // Get leadership data from translations
+
   const leadership = t.raw("leadership") as {
     title: string;
     description: string;
     skills: string[];
   };
 
-  const getTechIcon = (techName: string) => {
-    const lowerName = techName.toLowerCase();
-    if (lowerName.includes("react")) return SiReactnative;
-    if (lowerName.includes("swift")) return SiSwift;
-    if (lowerName.includes("next")) return SiNextdotjs;
-    if (lowerName.includes("aws")) return SiAws;
-    if (lowerName.includes("mongo")) return SiMongodb;
-    if (lowerName.includes("python")) return SiPython;
-    if (lowerName.includes("tensor")) return SiTensorflow;
-    if (lowerName.includes("node")) return SiNodedotjs;
-    if (lowerName.includes("vercel")) return SiVercel;
-    if (lowerName.includes("google") || lowerName.includes("gcp"))
-      return SiGooglecloud;
-    if (lowerName.includes("nginx")) return SiNginx;
-    if (lowerName.includes("maria")) return SiMariadb;
-    if (lowerName.includes("postgre")) return SiPostgresql;
-    if (lowerName.includes("typescript")) return SiTypescript;
-    if (lowerName.includes("tailwind")) return SiTailwindcss;
-    return SiReactnative; // Default icon
-  };
-
   const projects = projectsList.map((project, index) => {
-    const icons = [Globe, Smartphone, Globe, BookOpen, Brain];
-    const colors = ["purple", "blue", "green", "orange", "red"];
-    const statuses = ["ongoing", "completed", "active", "completed", "ongoing"];
-    const years = [
-      tDates("yearToPresent", { year: "2025" }),
-      tDates("yearRange", { start: "2022", end: "2023" }),
-      tDates("yearRange", { start: "2023", end: "2024" }),
-      tDates("yearRange", { start: "2021", end: "2022" }),
-      tDates("yearToPresent", { year: "2023" })
-    ];
-
-    return {
-      ...project,
-      icon: icons[index] || Globe,
-      color: colors[index] || "gray",
-      status: statuses[index] || "ongoing",
-      year: years[index] || "2024",
-      technologies: project.technologies.map((tech) => ({
-        name: tech,
-        icon: getTechIcon(tech),
-      })),
-    };
+    const meta = projectMeta[index];
+    if (!meta) {
+      return { ...project, id: `project-${index + 1}`, status: null as ProjectStatus | null, period: null as string | null };
+    }
+    const period =
+      meta.status === "ongoing"
+        ? tDates("yearToPresent", { year: meta.period.startYear })
+        : tDates("yearRange", {
+            start: meta.period.startYear,
+            end: meta.period.endYear ?? meta.period.startYear,
+          });
+    return { ...project, id: meta.id, status: meta.status, period };
   });
 
-
-  const getColorClasses = (color: string) => {
-    switch (color) {
-      case "blue":
-        return {
-          bg: "bg-blue-50 dark:bg-blue-900/20",
-          border: "border-blue-200 dark:border-blue-800",
-          accent: "bg-blue-600",
-          text: "text-blue-600 dark:text-blue-400",
-        };
-      case "green":
-        return {
-          bg: "bg-green-50 dark:bg-green-900/20",
-          border: "border-green-200 dark:border-green-800",
-          accent: "bg-green-600",
-          text: "text-green-600 dark:text-green-400",
-        };
-      case "purple":
-        return {
-          bg: "bg-purple-50 dark:bg-purple-900/20",
-          border: "border-purple-200 dark:border-purple-800",
-          accent: "bg-purple-600",
-          text: "text-purple-600 dark:text-purple-400",
-        };
-      case "red":
-        return {
-          bg: "bg-red-50 dark:bg-red-900/20",
-          border: "border-red-200 dark:border-red-800",
-          accent: "bg-red-600",
-          text: "text-red-600 dark:text-red-400",
-        };
-      case "orange":
-        return {
-          bg: "bg-orange-50 dark:bg-orange-900/20",
-          border: "border-orange-200 dark:border-orange-800",
-          accent: "bg-orange-600",
-          text: "text-orange-600 dark:text-orange-400",
-        };
-      default:
-        return {
-          bg: "bg-gray-50 dark:bg-gray-900/20",
-          border: "border-gray-200 dark:border-gray-800",
-          accent: "bg-gray-600",
-          text: "text-gray-600 dark:text-gray-400",
-        };
-    }
-  };
-
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "completed":
-        return {
-          label: tStatus("completed"),
-          color:
-            "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400",
-        };
-      case "active":
-        return {
-          label: tStatus("active"),
-          color:
-            "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400",
-        };
-      case "ongoing":
-        return {
-          label: tStatus("ongoing"),
-          color:
-            "bg-orange-100 text-orange-800 dark:bg-orange-900/20 dark:text-orange-400",
-        };
-      default:
-        return {
-          label: tStatus("undefined"),
-          color:
-            "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400",
-        };
-    }
-  };
-
   return (
-    <section id="projects" className="pt-24 pb-16 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50">
-      <div className="container mx-auto px-6">
-        {/* Header */}
-        <div className="text-center mb-20">
-          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
-            {tBadges("featuredProjects")}
-          </div>
-          <h2 className="text-4xl md:text-5xl lg:text-6xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-            {t("title")}
-          </h2>
-          <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
-            {t("subtitle")}
+    <section id="projects" className="py-24 bg-[color:var(--color-paper)]">
+      <div className="container mx-auto px-6 sm:px-10 max-w-5xl">
+        <header className="mb-12">
+          <p className="meta">{t("title")} · 2021 —</p>
+        </header>
+
+        <blockquote className="border-l border-[color:var(--color-teal-ink)] pl-6 my-16 max-w-3xl">
+          <p className="headline-italic text-xl sm:text-2xl text-[color:var(--color-ink)] leading-[1.35]">
+            &ldquo;{leadership.description}&rdquo;
           </p>
-        </div>
+          <footer className="meta mt-3">
+            {leadership.title}
+            {leadership.skills.length > 0 && (
+              <>
+                <span aria-hidden="true" className="mx-2 opacity-60">·</span>
+                <span>{leadership.skills.join(" · ")}</span>
+              </>
+            )}
+          </footer>
+        </blockquote>
 
-        {/* Leadership Section */}
-        <div className="mb-16">
-          <div className="max-w-4xl mx-auto bg-white dark:bg-slate-800 rounded-2xl p-6 border-l-4 border-l-teal-500 shadow-md hover:shadow-lg transition-shadow duration-200">
-            <div className="flex items-start gap-6">
-              <div className="p-4 rounded-2xl bg-green-600 text-white shadow-lg">
-                <Users size={32} />
-              </div>
-              <div className="flex-1">
-                <h3 className="text-3xl font-bold text-slate-800 dark:text-white mb-4">
-                  {leadership.title}
-                </h3>
-                <p className="text-lg text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
-                  {leadership.description}
-                </p>
-                <div className="flex flex-wrap gap-3">
-                  {leadership.skills.map((skill, skillIndex) => (
-                    <span
-                      key={skillIndex}
-                      className="px-4 py-2 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded-full text-sm font-semibold border border-green-200 dark:border-green-800"
-                    >
-                      {skill}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Projects Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10">
+        <ol className="divide-y divide-[color:var(--color-rule-soft)]">
           {projects.map((project, index) => {
-            const colors = getColorClasses(project.color);
-            const IconComponent = project.icon;
-            const statusBadge = getStatusBadge(project.status);
-
+            const ord = String(index + 1).padStart(2, "0");
             return (
-              <div
-                key={index}
-                className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-2xl p-6 border-l-4 border-l-teal-500 shadow-md hover:shadow-lg transition-shadow duration-200"
+              <li
+                key={project.id}
+                className="grid grid-cols-[auto_1fr] sm:grid-cols-[7rem_1fr] gap-6 sm:gap-10 py-10"
               >
-                {/* Background gradient overlay */}
-                <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                
-                <div className="relative z-10">
-                  {/* Header */}
-                  <div className="flex items-start justify-between mb-6">
-                    <div className="flex items-start gap-4">
-                      <div className={`p-4 rounded-2xl ${colors.accent} text-white shadow-lg transition-transform duration-200`}>
-                        <IconComponent size={28} />
-                      </div>
-                      <div>
-                        <h3 className="text-2xl font-bold text-slate-800 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
-                          {project.title}
-                        </h3>
-                        <div className="flex items-center gap-3">
-                          <span className={`px-3 py-1 rounded-full text-sm font-bold ${statusBadge.color} shadow-md transition-transform duration-200`}>
-                            {statusBadge.label}
-                          </span>
-                          <span className="text-sm text-slate-500 dark:text-slate-400 font-medium flex items-center gap-1">
-                            <Star size={14} />
-                            {project.year}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+                <div>
+                  <p className="headline-italic text-5xl sm:text-6xl text-[color:var(--color-ink)] leading-none">
+                    {ord}
+                  </p>
+                  {project.period && (
+                    <p className="meta mt-2">{project.period}</p>
+                  )}
+                  {project.status && (
+                    <p
+                      className={`meta mt-1 ${
+                        project.status === "ongoing"
+                          ? "text-[color:var(--color-teal-ink)]"
+                          : "text-[color:var(--color-ink-soft)]"
+                      }`}
+                    >
+                      {tStatus(project.status)}
+                    </p>
+                  )}
+                </div>
 
-                  </div>
-
-                  {/* Description */}
-                  <p className="text-slate-600 dark:text-slate-400 mb-6 leading-relaxed text-lg">
+                <div>
+                  <h3 className="text-2xl sm:text-3xl text-[color:var(--color-ink)] mb-3 leading-tight">
+                    {project.title}
+                  </h3>
+                  <p className="text-base sm:text-lg text-[color:var(--color-ink)] leading-[1.65] mb-5 max-w-prose">
                     {project.description}
                   </p>
 
-                  {/* Features */}
-                  <div className="mb-6">
-                    <h4 className="text-lg font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
-                      <div className="w-2 h-2 bg-blue-500 rounded-full" />
-                      {t("mainFeatures")}
-                    </h4>
-                    <ul className="space-y-3">
-                      {project.features.map((feature, featureIndex) => (
-                        <li
-                          key={featureIndex}
-                          className="text-slate-600 dark:text-slate-400 flex items-start gap-3"
-                        >
-                          <div className={`w-3 h-3 ${colors.accent} rounded-full mt-1.5 flex-shrink-0 shadow-md`} />
-                          <span className="font-medium">{feature}</span>
+                  {project.features.length > 0 && (
+                    <ul className="space-y-1 mb-5 text-[color:var(--color-ink-soft)] leading-relaxed max-w-prose">
+                      {project.features.map((feature, i) => (
+                        <li key={i} className="flex gap-3">
+                          <span aria-hidden="true" className="text-[color:var(--color-teal-ink)]">&mdash;</span>
+                          <span>{feature}</span>
                         </li>
                       ))}
                     </ul>
-                  </div>
+                  )}
 
-                  {/* Technologies */}
-                  <div>
-                    <h4 className="text-lg font-bold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
-                      <div className="w-2 h-2 bg-purple-500 rounded-full" />
-                      {t("techStack")}
-                    </h4>
-                    <div className="flex flex-wrap gap-3">
-                      {project.technologies.map((tech, techIndex) => {
-                        const TechIcon = tech.icon;
-                        return (
-                          <div
-                            key={techIndex}
-                            className="flex items-center gap-2 px-4 py-2 bg-white/80 dark:bg-slate-700/80 backdrop-blur-sm border border-slate-200/50 dark:border-slate-600/50 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"
-                          >
-                            <TechIcon size={18} />
-                            <span className="text-sm text-slate-700 dark:text-slate-300 font-semibold">
-                              {tech.name}
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
+                  <p className="meta text-[color:var(--color-ink-soft)]">
+                    {t("techStack")}
+                    <span aria-hidden="true" className="mx-2 opacity-60">·</span>
+                    <span className="text-[color:var(--color-ink)]">
+                      {project.technologies.join(" · ")}
+                    </span>
+                  </p>
                 </div>
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ol>
       </div>
     </section>
   );

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -1,11 +1,10 @@
 import { getTranslations } from "next-intl/server";
-import { ExternalLink } from "lucide-react";
 
 type Publication = {
   authors: string;
   year: number;
   title: string;
-  journal: string;
+  venue: string;
   volume?: string;
   pages?: string;
   doi?: string;
@@ -46,7 +45,7 @@ const ResearchSection = async () => {
       authors: item.authors,
       year: Number(item.year),
       title: item.title,
-      journal: item.journal,
+      venue: item.journal,
       volume: item.volume,
       pages: item.pages,
       doi: item.doi,
@@ -57,7 +56,7 @@ const ResearchSection = async () => {
       authors: item.authors,
       year: Number(item.year),
       title: item.title,
-      journal: item.conference,
+      venue: item.conference,
       link: item.link,
       type: "conference" as const,
     })),
@@ -70,89 +69,83 @@ const ResearchSection = async () => {
     });
 
   return (
-    <section id="research" className="pt-16 pb-20 bg-gradient-to-b from-slate-50/80 via-white to-slate-50/50 dark:from-slate-900/80 dark:via-slate-950 dark:to-slate-900/50">
-      <div className="container mx-auto px-6">
-        {/* Header */}
-        <div className="text-center mb-20">
-          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
+    <section id="research" className="py-24 bg-[color:var(--color-paper)]">
+      <div className="container mx-auto px-6 sm:px-10 max-w-5xl">
+        <header className="mb-12">
+          <p className="meta">
             {t("academicResearch")}
-          </div>
-          <h2 className="text-3xl md:text-4xl lg:text-5xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-            {t("title")}
-          </h2>
-          <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
-            {t("subtitle")}
-          </p>
-        </div>
-
-        {/* Publications */}
-        <div className="mt-20">
-          <h3 className="text-3xl font-bold text-slate-800 dark:text-white mb-12 text-center">
+            <span aria-hidden="true" className="mx-2 opacity-60">·</span>
             {t("publications")}
-          </h3>
+          </p>
+          <h2 className="headline-italic text-3xl sm:text-4xl text-[color:var(--color-ink)] mt-2 leading-tight max-w-3xl">
+            {t("title")} &mdash; {t("subtitle")}
+          </h2>
+        </header>
 
-          <div className="space-y-6 max-w-4xl mx-auto">
-            {publications.map((pub, index) => (
-              <div
+        <ol className="divide-y divide-[color:var(--color-rule-soft)]">
+          {publications.map((pub, index) => {
+            const num = String(index + 1).padStart(2, "0");
+            return (
+              <li
                 key={index}
-                className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-6 border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 transition-colors duration-200"
+                className="grid grid-cols-[3rem_1fr] sm:grid-cols-[5rem_1fr] gap-4 sm:gap-8 py-6"
               >
-                <div className="flex items-start justify-between flex-wrap gap-2">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex-1">
-                    {pub.title}
-                  </h3>
-                  <div className="flex items-center gap-2">
-                    <span className={`text-sm font-medium px-3 py-1 rounded-full ${
-                      pub.type === "journal"
-                        ? "text-purple-600 dark:text-purple-400 bg-purple-100 dark:bg-purple-900/30"
-                        : "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30"
-                    }`}>
-                      {pub.year}
-                    </span>
-                    <span className="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded">
-                      {pub.type === "journal" ? t("peerReviewedPapers") : t("conferencePresentations")}
-                    </span>
-                  </div>
+                <div>
+                  <p className="meta">{num}</p>
+                  <p className="meta mt-1 text-[color:var(--color-ink)]">
+                    {pub.year}
+                  </p>
+                  <p className="meta mt-1 opacity-70">
+                    {pub.type === "journal"
+                      ? t("peerReviewedPapers")
+                      : t("conferencePresentations")}
+                  </p>
                 </div>
-
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                  {pub.authors}
-                </p>
-
-                <p className="text-sm text-gray-700 dark:text-gray-300 mt-1 italic">
-                  {pub.journal}
-                  {pub.volume && `, ${pub.volume}`}
-                  {pub.pages && `, pp. ${pub.pages}`}
-                </p>
-
-                {(pub.doi || pub.link) && (
-                  <div className="mt-3">
-                    {pub.doi && (
-                      <a
-                        href={pub.doi}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline mr-4"
-                      >
-                        {t("doi")}
-                      </a>
-                    )}
-                    {pub.link && (
-                      <a
-                        href={pub.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
-                      >
-                        {pubT("viewPaper")} <ExternalLink size={14} />
-                      </a>
-                    )}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
+                <div className="pl-2 sm:pl-0">
+                  <p className="text-[color:var(--color-ink)] leading-[1.6]">
+                    <span className="text-[color:var(--color-ink-soft)]">
+                      {pub.authors}
+                    </span>
+                    .{" "}
+                    <span className="text-[color:var(--color-ink)]">
+                      {pub.title}
+                    </span>
+                    .{" "}
+                    <span className="headline-italic text-[color:var(--color-ink)]">
+                      {pub.venue}
+                    </span>
+                    {pub.volume && `, ${pub.volume}`}
+                    {pub.pages && `, pp. ${pub.pages}`}.
+                  </p>
+                  {(pub.doi || pub.link) && (
+                    <p className="meta mt-2">
+                      {pub.doi && (
+                        <a
+                          href={pub.doi}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[color:var(--color-teal-ink)] hover:underline underline-offset-2 mr-4"
+                        >
+                          {t("doi")}
+                        </a>
+                      )}
+                      {pub.link && (
+                        <a
+                          href={pub.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[color:var(--color-teal-ink)] hover:underline underline-offset-2"
+                        >
+                          {pubT("viewPaper")} ↗
+                        </a>
+                      )}
+                    </p>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
       </div>
     </section>
   );

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,130 +1,77 @@
 import { getTranslations } from "next-intl/server";
-import {
-  Code,
-  Monitor,
-  Server,
-  Database,
-  Cloud,
-  Brain,
-  Globe,
-  TrendingUp,
-  Award,
-} from "lucide-react";
-import {
-  SiJavascript,
-  SiTypescript,
-  SiPython,
-  SiSwift,
-  SiReact,
-  SiNextdotjs,
-  SiNodedotjs,
-  SiDjango,
-  SiMongodb,
-  SiMariadb,
-  SiReact as SiReactnative,
-  SiAwsamplify as SiAws,
-  SiGooglecloud,
-  SiVercel,
-  SiPytorch,
-  SiTensorflow,
-} from "react-icons/si";
+
+type Skill = { name: string; level: number };
+
+const skillCategories: Array<{ titleKey: string; skills: Skill[] }> = [
+  {
+    titleKey: "programming",
+    skills: [
+      { name: "JavaScript", level: 95 },
+      { name: "TypeScript", level: 90 },
+      { name: "Python", level: 85 },
+      { name: "Swift", level: 80 },
+    ],
+  },
+  {
+    titleKey: "frontend",
+    skills: [
+      { name: "React", level: 95 },
+      { name: "Next.js", level: 90 },
+      { name: "React Native", level: 85 },
+    ],
+  },
+  {
+    titleKey: "backend",
+    skills: [
+      { name: "Node.js", level: 90 },
+      { name: "Django", level: 85 },
+    ],
+  },
+  {
+    titleKey: "database",
+    skills: [
+      { name: "MongoDB", level: 90 },
+      { name: "MariaDB", level: 85 },
+    ],
+  },
+  {
+    titleKey: "cloud",
+    skills: [
+      { name: "AWS", level: 85 },
+      { name: "Google Cloud", level: 80 },
+      { name: "Vercel", level: 90 },
+    ],
+  },
+  {
+    titleKey: "ai",
+    skills: [
+      { name: "PyTorch", level: 85 },
+      { name: "TensorFlow", level: 80 },
+    ],
+  },
+];
 
 const SkillsSection = async () => {
   const t = await getTranslations("skills");
-
-  const skillCategories = [
-    {
-      titleKey: "programming",
-      icon: Code,
-      color: "blue",
-      skills: [
-        { name: "JavaScript", icon: SiJavascript, level: 95, color: "#F7DF1E" },
-        { name: "TypeScript", icon: SiTypescript, level: 90, color: "#3178C6" },
-        { name: "Python", icon: SiPython, level: 85, color: "#3776AB" },
-        { name: "Swift", icon: SiSwift, level: 80, color: "#FA7343" },
-      ],
-    },
-    {
-      titleKey: "frontend",
-      icon: Monitor,
-      color: "purple",
-      skills: [
-        { name: "React", icon: SiReact, level: 95, color: "#61DAFB" },
-        { name: "Next.js", icon: SiNextdotjs, level: 90, color: "#000000" },
-        {
-          name: "React Native",
-          icon: SiReactnative,
-          level: 85,
-          color: "#61DAFB",
-        },
-      ],
-    },
-    {
-      titleKey: "backend",
-      icon: Server,
-      color: "green",
-      skills: [
-        { name: "Node.js", icon: SiNodedotjs, level: 90, color: "#339933" },
-        { name: "Django", icon: SiDjango, level: 85, color: "#092E20" },
-      ],
-    },
-    {
-      titleKey: "database",
-      icon: Database,
-      color: "orange",
-      skills: [
-        { name: "MongoDB", icon: SiMongodb, level: 90, color: "#47A248" },
-        { name: "MariaDB", icon: SiMariadb, level: 85, color: "#003545" },
-      ],
-    },
-    {
-      titleKey: "cloud",
-      icon: Cloud,
-      color: "indigo",
-      skills: [
-        { name: "AWS", icon: SiAws, level: 85, color: "#232F3E" },
-        {
-          name: "Google Cloud",
-          icon: SiGooglecloud,
-          level: 80,
-          color: "#4285F4",
-        },
-        { name: "Vercel", icon: SiVercel, level: 90, color: "#000000" },
-      ],
-    },
-    {
-      titleKey: "ai",
-      icon: Brain,
-      color: "pink",
-      skills: [
-        { name: "PyTorch", icon: SiPytorch, level: 85, color: "#EE4C2C" },
-        { name: "TensorFlow", icon: SiTensorflow, level: 80, color: "#FF6F00" },
-      ],
-    },
-  ];
 
   const languages = [
     {
       name: t("languageProficiency.japanese"),
       level: 100,
       description: t("languageProficiency.japaneseLevel"),
-      flag: "🇯🇵",
     },
     {
       name: t("languageProficiency.chinese"),
       level: 100,
       description: t("languageProficiency.chineseLevel"),
-      flag: "🇨🇳",
     },
     {
       name: t("languageProficiency.english"),
       level: 75,
       description: t("languageProficiency.englishLevel"),
-      flag: "🇺🇸",
     },
   ];
 
-  // Get certifications from translations
   const certifications = t.raw("certifications") as {
     title: string;
     subtitle: string;
@@ -136,227 +83,94 @@ const SkillsSection = async () => {
     }>;
   };
 
-
-  const getColorClasses = (color: string) => {
-    switch (color) {
-      case "blue":
-        return "bg-blue-500";
-      case "purple":
-        return "bg-purple-500";
-      case "green":
-        return "bg-green-500";
-      case "orange":
-        return "bg-orange-500";
-      case "indigo":
-        return "bg-indigo-500";
-      case "pink":
-        return "bg-pink-500";
-      default:
-        return "bg-gray-500";
-    }
-  };
-
   return (
-    <section id="skills" className="py-20 bg-gradient-to-b from-white via-slate-50/30 to-white dark:from-slate-900 dark:via-slate-950/30 dark:to-slate-900">
-      <div className="container mx-auto px-6">
-        {/* Header */}
-        <div className="text-center mb-20">
-          <div className="text-sm font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-4">
-            {t("technicalExpertise")}
-          </div>
-          <h2 className="text-4xl md:text-5xl font-black text-slate-900 dark:text-white mb-6 tracking-tight">
-            {t("title")}
+    <section id="skills" className="py-24 bg-[color:var(--color-paper)]">
+      <div className="container mx-auto px-6 sm:px-10 max-w-5xl">
+        <header className="mb-16">
+          <p className="meta mb-3">{t("technicalExpertise")}</p>
+          <h2 className="text-3xl sm:text-4xl text-[color:var(--color-ink)]">
+            §&nbsp; {t("title")}
           </h2>
-          <p className="text-xl md:text-2xl text-slate-600 dark:text-slate-400 max-w-3xl mx-auto leading-relaxed">
-            {t("subtitle")}
-          </p>
-        </div>
+        </header>
 
-        {/* Technical Skills */}
-        <div className="mb-24">
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-            {skillCategories.map((category, categoryIndex) => {
-              const IconComponent = category.icon;
-
-              return (
-                <div
-                  key={categoryIndex}
-                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
-                >
-                  {/* Background gradient */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-pink-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                  
-                  <div className="relative z-10">
-                    <div className="flex items-center mb-8">
-                      <div className={`p-4 rounded-2xl ${getColorClasses(category.color)} text-white mr-4 shadow-lg transition-transform duration-200`}>
-                        <IconComponent size={28} />
-                      </div>
-                      <h3 className="text-2xl font-bold text-slate-800 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
-                        {t(category.titleKey)}
-                      </h3>
-                    </div>
-
-                    <div className="space-y-6">
-                      {category.skills.map((skill, skillIndex) => {
-                        const SkillIcon = skill.icon;
-
-                        return (
-                          <div 
-                            key={skillIndex} 
-                            className="space-y-3"
-                          >
-                            <div className="flex items-center justify-between">
-                              <div className="flex items-center gap-4">
-                                <div className="p-2 bg-white dark:bg-slate-700 rounded-xl shadow-md">
-                                  <SkillIcon
-                                    size={24}
-                                    style={{ color: skill.color }}
-                                  />
-                                </div>
-                                <span className="text-slate-700 dark:text-slate-300 font-semibold text-lg">
-                                  {skill.name}
-                                </span>
-                              </div>
-                              <span className="text-sm font-bold text-slate-500 dark:text-slate-400 px-3 py-1 bg-slate-100 dark:bg-slate-700 rounded-full">
-                                {skill.level}%
-                              </span>
-                            </div>
-                            
-                            <div className="relative w-full bg-slate-200 dark:bg-slate-700 rounded-full h-3 overflow-hidden">
-                              <div
-                                className="h-full rounded-full relative overflow-hidden"
-                                style={{
-                                  background: `linear-gradient(90deg, ${skill.color}99, ${skill.color})`,
-                                  width: '100%',
-                                  transform: `scaleX(${skill.level / 100})`,
-                                  transformOrigin: 'left',
-                                  transition: 'transform 1s ease-out'
-                                }}
-                              >
-                                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent" />
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Certifications */}
-        <div className="mb-24">
-          <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
-              <div className="p-2 bg-gradient-to-r from-amber-500 to-orange-600 rounded-lg shadow-lg">
-                <Award className="text-white" size={20} />
-              </div>
-              <span className="font-bold text-slate-800 dark:text-white">{certifications.title}</span>
-            </div>
-            <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
-              {certifications.subtitle}
-            </p>
-          </div>
-
-          <div className="max-w-5xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {certifications.list.map((cert, index) => (
-                <div
-                  key={index}
-                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-2xl p-6 border border-slate-200/50 dark:border-slate-700/50 shadow-lg hover:shadow-xl transition-all duration-200"
-                >
-                  
-                  <div className="relative z-10">
-                    <div className="flex items-start justify-between mb-4">
-                      <div className="p-3 bg-gradient-to-r from-amber-500/20 to-orange-600/20 rounded-xl">
-                        <Award className="text-amber-600 dark:text-amber-400" size={24} />
-                      </div>
-                      <span className="text-sm font-medium text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-3 py-1 rounded-full">
-                        {cert.date}
+        <dl className="divide-y divide-[color:var(--color-rule-soft)]">
+          {skillCategories.map((category) => (
+            <div
+              key={category.titleKey}
+              className="grid grid-cols-1 sm:grid-cols-[14rem_1fr] gap-2 sm:gap-8 py-6"
+            >
+              <dt className="headline-italic text-xl sm:text-2xl text-[color:var(--color-ink)] leading-tight">
+                {t(category.titleKey)}
+              </dt>
+              <dd className="text-[color:var(--color-ink)] leading-[1.7]">
+                {category.skills.map((skill, i) => (
+                  <span key={skill.name}>
+                    {skill.name}
+                    <span className="meta ml-1 align-baseline">
+                      {skill.level}
+                    </span>
+                    {i < category.skills.length - 1 && (
+                      <span aria-hidden="true" className="mx-2 text-[color:var(--color-ink-soft)]">
+                        ·
                       </span>
-                    </div>
-                    
-                    <h4 className="text-lg font-bold text-slate-800 dark:text-white mb-3 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors duration-200">
-                      {cert.name}
-                    </h4>
-                    
-                    <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed">
-                      {cert.description}
-                    </p>
-                  </div>
-                </div>
-              ))}
+                    )}
+                  </span>
+                ))}
+              </dd>
             </div>
-          </div>
+          ))}
+        </dl>
+
+        <div className="mt-24">
+          <p className="meta mb-3">{certifications.subtitle}</p>
+          <h3 className="text-2xl sm:text-3xl text-[color:var(--color-ink)] mb-8">
+            {certifications.title}
+          </h3>
+
+          <ul className="divide-y divide-[color:var(--color-rule-soft)]">
+            {certifications.list.map((cert, index) => (
+              <li
+                key={index}
+                className="grid grid-cols-1 sm:grid-cols-[8rem_1fr] gap-1 sm:gap-8 py-5"
+              >
+                <span className="meta self-start">{cert.date}</span>
+                <div>
+                  <p className="text-lg text-[color:var(--color-ink)]">
+                    {cert.name}
+                  </p>
+                  <p className="text-sm text-[color:var(--color-ink-soft)] mt-1 leading-relaxed">
+                    {cert.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
 
-        {/* Language Skills */}
-        <div>
-          <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-3 px-6 py-3 bg-white/80 dark:bg-slate-800/80 border border-slate-200/50 dark:border-slate-700/50 rounded-full shadow-lg mb-8">
-              <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-600 rounded-lg shadow-lg">
-                <Globe className="text-white" size={20} />
+        <div className="mt-24">
+          <p className="meta mb-3">{t("proficiency")}</p>
+          <h3 className="text-2xl sm:text-3xl text-[color:var(--color-ink)] mb-8">
+            {t("languages")}
+          </h3>
+
+          <dl className="divide-y divide-[color:var(--color-rule-soft)]">
+            {languages.map((lang) => (
+              <div
+                key={lang.name}
+                className="grid grid-cols-1 sm:grid-cols-[8rem_1fr_auto] items-baseline gap-2 sm:gap-8 py-5"
+              >
+                <dt className="headline-italic text-xl text-[color:var(--color-ink)]">
+                  {lang.name}
+                </dt>
+                <dd className="text-[color:var(--color-ink-soft)] leading-relaxed">
+                  {lang.description}
+                </dd>
+                <span className="meta justify-self-start sm:justify-self-end">
+                  {lang.level}
+                </span>
               </div>
-              <span className="font-bold text-slate-800 dark:text-white">{t("languages")}</span>
-            </div>
-          </div>
-
-          <div className="max-w-5xl mx-auto">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-              {languages.map((language, index) => (
-                <div
-                  key={index}
-                  className="group relative overflow-hidden bg-white dark:bg-slate-800 rounded-3xl p-8 border border-slate-200/50 dark:border-slate-700/50 shadow-xl hover:shadow-2xl transition-all duration-200"
-                >
-                  {/* Background gradient */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-emerald-50/50 dark:from-blue-950/20 dark:via-purple-950/10 dark:to-emerald-950/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                  
-                  <div className="relative z-10 text-center">
-                    <div className="text-6xl mb-6 filter drop-shadow-lg">
-                      {language.flag}
-                    </div>
-                    
-                    <h4 className="text-2xl font-bold text-slate-800 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors duration-200">
-                      {language.name}
-                    </h4>
-                    
-                    <p className="text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
-                      {language.description}
-                    </p>
-
-                    <div className="space-y-4">
-                      <div className="flex justify-between items-center">
-                        <span className="font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                          <TrendingUp size={16} />
-                          {t("proficiency")}
-                        </span>
-                        <span className="font-bold text-lg text-slate-800 dark:text-white px-3 py-1 bg-blue-100 dark:bg-blue-900/30 rounded-full">
-                          {language.level}%
-                        </span>
-                      </div>
-                      
-                      <div className="relative w-full bg-slate-200 dark:bg-slate-700 rounded-full h-4 overflow-hidden">
-                        <div
-                          className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500 rounded-full relative overflow-hidden"
-                          style={{
-                            width: '100%',
-                            transform: `scaleX(${language.level / 100})`,
-                            transformOrigin: 'left',
-                            transition: 'transform 1s ease-out'
-                          }}
-                        >
-                          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent" />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+            ))}
+          </dl>
         </div>
       </div>
     </section>

--- a/src/components/TeachingSection.tsx
+++ b/src/components/TeachingSection.tsx
@@ -1,186 +1,130 @@
 import { getTranslations } from "next-intl/server";
-import { GraduationCap, Users, Clock, Award, BookOpen, Target } from "lucide-react";
 
 export default async function TeachingSection() {
   const t = await getTranslations("teaching");
 
   const stats = [
-    {
-      icon: GraduationCap,
-      value: "7",
-      label: t("yearsExperience"),
-      color: "from-blue-500 to-cyan-500",
-    },
-    {
-      icon: Clock,
-      value: "5,000+",
-      label: t("teachingHours"),
-      color: "from-purple-500 to-pink-500",
-    },
-    {
-      icon: Users,
-      value: "300+",
-      label: t("studentsTotal"),
-      color: "from-green-500 to-emerald-500",
-    },
-    {
-      icon: Target,
-      value: "95%",
-      label: t("passRate"),
-      color: "from-orange-500 to-red-500",
-    },
+    { value: "7", label: t("yearsExperience") },
+    { value: "5,000+", label: t("teachingHours") },
+    { value: "300+", label: t("studentsTotal") },
+    { value: "95%", label: t("passRate") },
   ];
 
   const courses = [
     {
       title: t("courses.basic.title"),
       description: t("courses.basic.description"),
-      icon: BookOpen,
       features: t.raw("courses.basic.features") as string[],
     },
     {
       title: t("courses.jlpt.title"),
       description: t("courses.jlpt.description"),
-      icon: Award,
       features: t.raw("courses.jlpt.features") as string[],
     },
     {
       title: t("courses.business.title"),
       description: t("courses.business.description"),
-      icon: Users,
       features: t.raw("courses.business.features") as string[],
     },
   ];
 
   return (
-    <section id="teaching" className="pt-20 pb-16">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-12">
-          <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
-            {t("title")}
-          </h2>
-          <p className="text-xl text-gray-600 dark:text-gray-400">
+    <section id="teaching" className="py-24 bg-[color:var(--color-paper)]">
+      <div className="container mx-auto px-6 sm:px-10 max-w-5xl">
+        <header className="mb-12">
+          <p className="meta">{t("title")}</p>
+          <h2 className="headline-italic text-3xl sm:text-4xl text-[color:var(--color-ink)] mt-2 leading-tight max-w-3xl">
             {t("subtitle")}
+          </h2>
+        </header>
+
+        <div className="border-t border-[color:var(--color-rule)] border-b border-[color:var(--color-rule)] py-10 mb-16">
+          <p className="headline-italic text-2xl sm:text-3xl text-[color:var(--color-teal-ink)] mb-2">
+            JLPT N1
+          </p>
+          <p className="text-4xl sm:text-6xl text-[color:var(--color-ink)] headline-italic tracking-tight leading-none">
+            180 / 180
+          </p>
+          <p className="meta mt-3 text-[color:var(--color-ink-soft)]">
+            {t("perfectScore")} &mdash; {t("perfectScoreDescription")}
           </p>
         </div>
 
-        {/* JLPT Perfect Score Badge */}
-        <div className="max-w-md mx-auto mb-12">
-          <div className="bg-gradient-to-r from-yellow-400 to-orange-500 p-1 rounded-2xl shadow-lg">
-            <div className="bg-white dark:bg-slate-900 rounded-2xl p-6 text-center">
-              <Award className="w-12 h-12 mx-auto mb-3 text-yellow-500" />
-              <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-                JLPT N1 {t("perfectScore")}
-              </h3>
-              <p className="text-3xl font-bold text-transparent bg-gradient-to-r from-yellow-500 to-orange-500 bg-clip-text">
-                180/180
-              </p>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                {t("perfectScoreDescription")}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Statistics */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16">
-          {stats.map((stat, index) => (
-            <div
-              key={index}
-              className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors duration-200"
-            >
-              <div className={`bg-gradient-to-r ${stat.color} p-3 rounded-lg w-fit mb-4`}>
-                <stat.icon className="w-6 h-6 text-white" />
-              </div>
-              <div className="text-3xl font-bold text-gray-900 dark:text-white mb-1">
+        <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-8 mb-20">
+          {stats.map((stat) => (
+            <div key={stat.label} className="border-t border-[color:var(--color-rule-soft)] pt-4">
+              <dt className="meta mb-2">{stat.label}</dt>
+              <dd className="headline-italic text-4xl sm:text-5xl text-[color:var(--color-ink)] leading-none">
                 {stat.value}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">
-                {stat.label}
-              </div>
+              </dd>
             </div>
           ))}
-        </div>
+        </dl>
 
-        {/* Teaching Experience */}
-        <div className="mb-16">
-          <h3 className="text-2xl font-bold text-center mb-8 text-gray-900 dark:text-white">
-            {t("experienceTitle")}
+        <div className="mb-20">
+          <p className="meta mb-2">{t("experienceTitle")}</p>
+          <h3 className="headline-italic text-2xl sm:text-3xl text-[color:var(--color-ink)] mb-6">
+            {t("newOriental")}
           </h3>
-          <div className="max-w-3xl mx-auto bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-900/20 dark:to-purple-900/20 rounded-2xl p-8">
-            <h4 className="text-xl font-semibold mb-4 text-indigo-600 dark:text-indigo-400">
-              {t("newOriental")}
-            </h4>
-            <p className="text-gray-700 dark:text-gray-300 mb-4">
-              {t("experienceDescription")}
-            </p>
-            <div className="grid md:grid-cols-2 gap-4">
-              <div className="bg-white/50 dark:bg-slate-800/50 rounded-lg p-4">
-                <h5 className="font-semibold text-gray-900 dark:text-white mb-2">
-                  {t("achievements")}
-                </h5>
-                <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
-                  <li>• {t("achievement1")}</li>
-                  <li>• {t("achievement2")}</li>
-                  <li>• {t("achievement3")}</li>
-                </ul>
-              </div>
-              <div className="bg-white/50 dark:bg-slate-800/50 rounded-lg p-4">
-                <h5 className="font-semibold text-gray-900 dark:text-white mb-2">
-                  {t("specialties")}
-                </h5>
-                <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
-                  <li>• {t("specialty1")}</li>
-                  <li>• {t("specialty2")}</li>
-                  <li>• {t("specialty3")}</li>
-                </ul>
-              </div>
+          <p className="text-[color:var(--color-ink)] leading-[1.7] max-w-3xl mb-8">
+            {t("experienceDescription")}
+          </p>
+          <div className="grid sm:grid-cols-2 gap-10 max-w-3xl">
+            <div>
+              <p className="meta mb-3">{t("achievements")}</p>
+              <ul className="space-y-1 text-[color:var(--color-ink)]">
+                <li>&mdash; {t("achievement1")}</li>
+                <li>&mdash; {t("achievement2")}</li>
+                <li>&mdash; {t("achievement3")}</li>
+              </ul>
+            </div>
+            <div>
+              <p className="meta mb-3">{t("specialties")}</p>
+              <ul className="space-y-1 text-[color:var(--color-ink)]">
+                <li>&mdash; {t("specialty1")}</li>
+                <li>&mdash; {t("specialty2")}</li>
+                <li>&mdash; {t("specialty3")}</li>
+              </ul>
             </div>
           </div>
         </div>
 
-        {/* Courses */}
         <div>
-          <h3 className="text-2xl font-bold text-center mb-8 text-gray-900 dark:text-white">
-            {t("coursesOffered")}
-          </h3>
-          <div className="grid md:grid-cols-3 gap-6">
-            {courses.map((course, index) => (
-              <div
-                key={index}
-                className="bg-white dark:bg-slate-800 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors duration-200"
-              >
-                <div className="bg-gradient-to-r from-indigo-500 to-purple-500 p-3 rounded-lg w-fit mb-4">
-                  <course.icon className="w-6 h-6 text-white" />
-                </div>
-                <h4 className="text-xl font-semibold mb-3 text-gray-900 dark:text-white">
-                  {course.title}
-                </h4>
-                <p className="text-gray-600 dark:text-gray-400 mb-4">
-                  {course.description}
-                </p>
-                <ul className="space-y-2">
-                  {course.features.map((feature, idx) => (
-                    <li
-                      key={idx}
-                      className="flex items-start text-sm text-gray-600 dark:text-gray-400"
-                    >
-                      <span className="text-indigo-500 mr-2">•</span>
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
+          <p className="meta mb-6">{t("coursesOffered")}</p>
+          <ol className="divide-y divide-[color:var(--color-rule-soft)]">
+            {courses.map((course, index) => {
+              const ord = String(index + 1).padStart(2, "0");
+              return (
+                <li
+                  key={index}
+                  className="grid grid-cols-[3rem_1fr] sm:grid-cols-[5rem_1fr] gap-4 sm:gap-8 py-6"
+                >
+                  <p className="meta text-[color:var(--color-ink)]">{ord}</p>
+                  <div>
+                    <h4 className="text-xl sm:text-2xl text-[color:var(--color-ink)] mb-2 leading-tight">
+                      {course.title}
+                    </h4>
+                    <p className="text-[color:var(--color-ink-soft)] leading-relaxed mb-3 max-w-prose">
+                      {course.description}
+                    </p>
+                    <ul className="space-y-1 text-[color:var(--color-ink-soft)] max-w-prose">
+                      {course.features.map((feature, idx) => (
+                        <li key={idx} className="flex gap-3">
+                          <span aria-hidden="true" className="text-[color:var(--color-teal-ink)]">&mdash;</span>
+                          <span>{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
         </div>
 
-        {/* Teaching Philosophy */}
-        <div className="mt-16 text-center max-w-3xl mx-auto">
-          <h3 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">
-            {t("philosophyTitle")}
-          </h3>
-          <p className="text-lg text-gray-600 dark:text-gray-400 italic">
+        <div className="mt-24 border-t border-[color:var(--color-rule)] pt-10 max-w-3xl">
+          <p className="meta mb-3">{t("philosophyTitle")}</p>
+          <p className="headline-italic text-xl sm:text-2xl text-[color:var(--color-ink)] leading-[1.55]">
             &ldquo;{t("philosophyQuote")}&rdquo;
           </p>
         </div>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,299 +1,68 @@
-"use client";
+import { getTranslations } from "next-intl/server";
 
-import { useTranslations } from "next-intl";
-import { m } from "framer-motion";
-import { useRef } from "react";
-import {
-  Baby,
-  Plane,
-  Home,
-  GraduationCap,
-  School,
-  University,
-  Rocket,
-  Calendar,
-  MapPin,
-} from "lucide-react";
-import Image from "next/image";
+type TimelineEvent = {
+  year: string;
+  title: string;
+  description: string;
+  icon?: string;
+};
 
-const TimelineSection = () => {
-  const t = useTranslations("about");
-  const locationsT = useTranslations("locations");
-  const containerRef = useRef<HTMLDivElement>(null);
+const locationByIndex: Array<"china" | "japan" | undefined> = [
+  "china", "japan", "china", "japan", "china", "japan", "japan",
+];
 
-  const timelineEvents = t.raw("timelineEvents") as Array<{
-    year: string;
-    title: string;
-    description: string;
-    icon?: string;
-  }>;
+const TimelineSection = async () => {
+  const t = await getTranslations("about");
+  const locationsT = await getTranslations("locations");
 
-  // Add location data to events
-  const eventsWithLocation = timelineEvents.map((event, index) => {
-    const locations: ("china" | "japan" | undefined)[] = [
-      "china", // 1997 birth
-      "japan", // 1999 move to Japan
-      "china", // 2009 back to China
-      "japan", // 2010 permanent residence
-      "china", // 2016 university
-      "japan", // 2021 Kyoto
-      "japan", // 2023 startup
-    ];
-    return {
+  const events = (t.raw("timelineEvents") as TimelineEvent[]).map(
+    (event, index) => ({
       ...event,
-      location: locations[index],
-      special: event.icon === "rocket" || event.icon === "university",
-    };
-  });
-
-  const getTimelineIcon = (icon?: string) => {
-    switch (icon) {
-      case "birth": return Baby;
-      case "plane": return Plane;
-      case "home": return Home;
-      case "school": return School;
-      case "university": return University;
-      case "graduation": return GraduationCap;
-      case "rocket": return Rocket;
-      default: return Calendar;
-    }
-  };
-
-  const getCountryColor = (location?: string) => {
-    switch (location) {
-      case "china":
-        return "from-red-500 to-yellow-500";
-      case "japan":
-        return "from-red-500 to-white";
-      default:
-        return "from-blue-500 to-purple-500";
-    }
-  };
-
-  const getCountryBg = (location?: string) => {
-    switch (location) {
-      case "china":
-        return "bg-gradient-to-br from-red-50 to-yellow-50 dark:from-red-950/20 dark:to-yellow-950/20";
-      case "japan":
-        return "bg-gradient-to-br from-red-50 to-slate-50 dark:from-red-950/20 dark:to-slate-950/20";
-      default:
-        return "bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20";
-    }
-  };
+      location: locationByIndex[index],
+      special:
+        event.icon === "rocket" ||
+        event.icon === "university" ||
+        event.icon === "graduation",
+    }),
+  );
 
   return (
-    <div ref={containerRef} className="relative py-20">
-      <h3 className="text-3xl font-bold text-slate-900 dark:text-white mb-16 text-center">
+    <div className="relative mt-20">
+      <h3 className="headline-italic text-3xl sm:text-4xl text-[color:var(--color-ink)] mb-10">
         {t("timeline")}
       </h3>
 
-
-      <div className="relative max-w-5xl mx-auto mt-20">
-        {/* Desktop flowing timeline paths */}
-        <div className="absolute inset-0 hidden lg:block pointer-events-none">
-          {eventsWithLocation.map((event, index) => {
-            if (index === eventsWithLocation.length - 1) return null;
-            
-            const isEven = index % 2 === 0;
-            const nextIsEven = (index + 1) % 2 === 0;
-            
-            // Calculate actual spacing based on the timeline layout
-            // space-y-32 = 8rem = 128px between cards
-            // Each card is approximately 200-250px in height
-            const cardSpacing = 128; // tailwind space-y-32
-            const cardHeight = 220; // estimated card height
-            const totalSpacing = cardSpacing + cardHeight;
-            
-            // Position from center of current card to center of next card
-            const yStart = index * totalSpacing + (cardHeight / 2);
-            const yEnd = (index + 1) * totalSpacing + (cardHeight / 2);
-            
-            return (
-              <m.svg
-                key={`flow-${index}`}
-                className="absolute w-full overflow-visible"
-                style={{ 
-                  top: `${yStart}px`, 
-                  height: `${yEnd - yStart}px` 
-                }}
-                viewBox="0 0 800 400"
-                preserveAspectRatio="none"
-                initial={{ opacity: 0 }}
-                whileInView={{ opacity: 1 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.8, delay: index * 0.05 }}
+      <ol className="divide-y divide-[color:var(--color-rule-soft)]">
+        {events.map((event, index) => (
+          <li
+            key={index}
+            className="grid grid-cols-[5rem_1fr] sm:grid-cols-[8rem_1fr] gap-4 sm:gap-10 py-6"
+          >
+            <div>
+              <p className="meta text-[color:var(--color-ink)]">{event.year}</p>
+              {event.location && (
+                <p className="meta mt-1 opacity-70">
+                  {locationsT(event.location)}
+                </p>
+              )}
+            </div>
+            <div>
+              <h4
+                className={`text-lg sm:text-xl mb-1 leading-tight ${
+                  event.special
+                    ? "text-[color:var(--color-teal-ink)]"
+                    : "text-[color:var(--color-ink)]"
+                }`}
               >
-                {/* Flowing path */}
-                <m.path
-                  d={
-                    isEven
-                      ? nextIsEven
-                        ? "M 200 10 Q 150 200, 200 390" // 左→左 (gentle curve)
-                        : "M 200 10 Q 300 200, 600 390" // 左→右 (flowing S-curve)
-                      : nextIsEven
-                        ? "M 600 10 Q 500 200, 200 390" // 右→左 (flowing S-curve)
-                        : "M 600 10 Q 650 200, 600 390" // 右→右 (gentle curve)
-                  }
-                  stroke="currentColor"
-                  className="text-slate-300 dark:text-slate-600"
-                  strokeWidth="2"
-                  fill="none"
-                  initial={{ pathLength: 0 }}
-                  whileInView={{ pathLength: 1 }}
-                  viewport={{ once: true }}
-                  transition={{
-                    pathLength: { duration: 1.5, delay: index * 0.1, ease: "easeInOut" }
-                  }}
-                />
-              </m.svg>
-            );
-          })}
-        </div>
-
-        {/* Mobile central line */}
-        <div className="absolute left-12 top-0 bottom-0 w-0.5 bg-gradient-to-b from-blue-400 via-purple-400 to-pink-400 lg:hidden" />
-
-        {/* Timeline events */}
-        <div className="relative space-y-16 lg:space-y-32">
-          {eventsWithLocation.map((event, index) => {
-            const Icon = getTimelineIcon(event.icon);
-            const isPlaneEvent = event.icon === "plane";
-            const isKyotoEvent = event.title.includes("京都大学") || event.title.includes("修士") || event.title.includes("博士");
-
-            return (
-              <m.div
-                key={index}
-                initial={{ opacity: 0, y: 50 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.5, delay: index * 0.1 }}
-                className={`relative ${
-                  index % 2 === 0 ? "lg:pr-1/2" : "lg:pl-1/2 lg:ml-auto"
-                } lg:w-1/2 ml-20 lg:ml-0`}
-              >
-                {/* Plane animation for travel events */}
-                {isPlaneEvent && (
-                  <m.div
-                    className="absolute -top-16 left-1/2 transform -translate-x-1/2 z-20"
-                    initial={{ x: event.location === "japan" ? -200 : 200, y: -50 }}
-                    whileInView={{ x: 0, y: 0 }}
-                    transition={{ duration: 1.5, type: "spring" }}
-                  >
-                    <div className="relative">
-                      <m.div
-                        animate={{ rotate: [0, 10, -10, 0] }}
-                        transition={{ duration: 2, repeat: Infinity }}
-                      >
-                        <Plane className="text-blue-500 w-12 h-12" />
-                      </m.div>
-                      <m.div
-                        className="absolute -bottom-4 left-1/2 transform -translate-x-1/2"
-                        initial={{ scale: 0 }}
-                        animate={{ scale: [0, 1.5, 0] }}
-                        transition={{ duration: 1.5, repeat: Infinity }}
-                      >
-                        <div className="w-2 h-2 bg-blue-400 rounded-full" />
-                      </m.div>
-                    </div>
-                  </m.div>
-                )}
-
-                {/* Mobile timeline dot */}
-                <div className="absolute -left-20 top-8 w-4 h-4 bg-white dark:bg-slate-900 rounded-full border-2 border-blue-400 shadow-lg lg:hidden z-10" />
-
-                {/* Desktop timeline dot - positioned at card edge */}
-                <div className={`absolute hidden lg:block w-6 h-6 bg-white dark:bg-slate-900 rounded-full shadow-lg z-20 ${
-                  index % 2 === 0 ? "-right-3 top-8" : "-left-3 top-8"
-                }`}>
-                  <div className={`absolute inset-0.5 bg-gradient-to-r ${getCountryColor(event.location)} rounded-full`} />
-                </div>
-                
-                {/* Connecting line from dot to card */}
-                <div className={`absolute hidden lg:block top-11 h-px bg-slate-300 dark:bg-slate-600 ${
-                  index % 2 === 0 
-                    ? "left-1/2 right-0 transform origin-left" 
-                    : "left-0 right-1/2 transform origin-right"
-                }`} />
-
-                <m.div
-                  className={`relative p-6 lg:p-8 rounded-2xl border-2 ${
-                    isKyotoEvent 
-                      ? "border-blue-300 dark:border-blue-700 shadow-2xl shadow-blue-200/50 dark:shadow-blue-900/50" 
-                      : event.special
-                      ? "border-yellow-300 dark:border-yellow-700 shadow-2xl" 
-                      : "border-slate-200 dark:border-slate-700 shadow-lg"
-                  } ${getCountryBg(event.location)} overflow-hidden`}
-                  whileHover={{ 
-                    scale: 1.02,
-                    transition: { type: "spring", stiffness: 300 }
-                  }}
-                >
-                  {/* Watermark logo for Kyoto University */}
-                  {isKyotoEvent && (
-                    <div className="absolute -top-6 -right-6 w-40 h-40 opacity-10 dark:opacity-5">
-                      <Image
-                        src="/kyoto-u-logo.svg"
-                        alt="Kyoto University"
-                        width={160}
-                        height={160}
-                        sizes="160px"
-                      />
-                    </div>
-                  )}
-
-
-                  <div className="flex items-start gap-4">
-                    {/* Icon with unified design */}
-                    <m.div 
-                      className={`p-3 bg-gradient-to-br ${getCountryColor(event.location)} rounded-xl shadow-lg`}
-                      whileHover={{ scale: 1.05 }}
-                      transition={{ type: "spring", stiffness: 300 }}
-                    >
-                      <Icon className="text-white" size={24} />
-                    </m.div>
-
-                    <div className="flex-1">
-                      {/* Year and location */}
-                      <div className="flex items-center gap-3 mb-2">
-                        <span className="text-lg font-bold text-slate-700 dark:text-slate-300">
-                          {event.year}
-                        </span>
-                        {event.location && (
-                          <div className="flex items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
-                            <MapPin size={14} />
-                            <span>{locationsT(event.location)}</span>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Title with special styling */}
-                      <h4 className={`text-xl font-bold mb-2 ${
-                        event.special 
-                          ? "bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent" 
-                          : "text-slate-900 dark:text-white"
-                      }`}>
-                        {event.title}
-                      </h4>
-
-                      {/* Description */}
-                      <p className="text-slate-600 dark:text-slate-400">
-                        {event.description}
-                      </p>
-
-                    </div>
-                  </div>
-                </m.div>
-              </m.div>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-1/4 left-0 w-96 h-96 bg-gradient-to-r from-blue-200 to-purple-200 dark:from-blue-900/20 dark:to-purple-900/20 rounded-full blur-3xl opacity-20" />
-        <div className="absolute bottom-1/4 right-0 w-96 h-96 bg-gradient-to-r from-pink-200 to-yellow-200 dark:from-pink-900/20 dark:to-yellow-900/20 rounded-full blur-3xl opacity-20" />
-      </div>
+                {event.title}
+              </h4>
+              <p className="text-[color:var(--color-ink-soft)] leading-relaxed max-w-prose">
+                {event.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
     </div>
   );
 };


### PR DESCRIPTION
_Re-opened against main after PR #55 (formerly #53) merged. Same content as #54._

## Summary
Rebuild the six content sections — Projects, Skills, About, Timeline, Research, Teaching — so they actually use the Phase-0 editorial tokens (paper / ink / hairline / teal / serif display / mono meta).

## What changed per section
- **Projects** → two-column editorial index (italic ordinal + year gutter, serif title + lede + features + inline tech line). Leadership becomes a teal-ruled pull-quote. Typed per-project meta covers **all 8 projects** with status + period — replaces the 5-element positional arrays with silent fallbacks.
- **Skills** → text-led reading rows. Italic serif category headings, inline `Name · 95` skills, certifications + languages share the same row system. No cards, no bars, no colored tiles.
- **About** → flat `<dl>` on hairlines, single dropcap lede gated to `lang="en"`.
- **Timeline** → static editorial chronology. All SVG `pathLength`, plane animation, hover scales, country gradients removed. Kyoto highlight flagged structurally via `event.icon` (fixes the locale bug).
- **Research** → bibliography format: numbered entries with year gutter, author / title / italic venue punctuated like an academic reference.
- **Teaching** → JLPT 180/180 banner between two hairlines, mono-labelled italic stat columns, numbered course list, philosophy pull-quote. Removes the invalid `dark:hover:bg-slate-750` class.

## Verification
- `npm run build` clean; lint clean.
- `/[locale]` First Load JS: 147 → 139 → **136 kB**. Shipped kB: 18.9 → 11.4 → **8.52**.
- Computed-style sweep over all 6 sections: **0** gradients, **0** rounded cards, **0** box-shadows, **0** backdrop-filters. `h1` = 1, `main` = 1.
- Codex stop-time review caught two project-metadata bugs during the session; both fixed before pushing.

## Out of scope
- `ZennFeed` + `LatestZennArticle` still render in the pre-Phase-0 style. To be handled in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)