### PR TITLE
Phase 1 · follow-up: restore timeline plane glyph (editorial)

### DIFF
--- a/src/components/TimelinePlaneMark.tsx
+++ b/src/components/TimelinePlaneMark.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Direction = "east" | "west";
+
+const TimelinePlaneMark = ({ direction }: { direction: Direction }) => {
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setVisible(true);
+      return;
+    }
+
+    const node = wrapperRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 0.6, rootMargin: "0px 0px -8% 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const enterTx = direction === "east" ? -18 : 18;
+  const enterRotate = direction === "east" ? -4 : 4;
+
+  return (
+    <span
+      ref={wrapperRef}
+      aria-hidden="true"
+      className="mt-2 justify-self-end translate-x-1 inline-block"
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible
+          ? "translateX(0) rotate(0deg)"
+          : `translateX(${enterTx}px) rotate(${enterRotate}deg)`,
+        transition:
+          "opacity 820ms cubic-bezier(0.22, 1, 0.36, 1), transform 820ms cubic-bezier(0.22, 1, 0.36, 1)",
+        willChange: "transform, opacity",
+      }}
+    >
+      <svg
+        viewBox="0 0 28 24"
+        fill="none"
+        aria-hidden="true"
+        className="w-9 h-6 sm:w-11 sm:h-7"
+        style={{
+          // Glyph path is authored pointing west (nose at x=2.5). Flip for east.
+          transform:
+            direction === "east" ? "scaleX(-1)" : undefined,
+          transformOrigin: "center",
+        }}
+      >
+        <path
+          d="M2.5 12.5L25 8.5M2.5 12.5L25 16.5M9.5 11.3L13.1 6.5M9.5 13.7L13.1 18.5M2.5 12.5H6.4"
+          pathLength={1}
+          stroke="var(--color-teal-ink)"
+          strokeWidth={1.25}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          style={{
+            strokeDasharray: 1,
+            strokeDashoffset: visible ? 0 : 1,
+            transition:
+              "stroke-dashoffset 620ms cubic-bezier(0.32, 0, 0.2, 1) 120ms",
+          }}
+        />
+      </svg>
+    </span>
+  );
+};
+
+export default TimelinePlaneMark;

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import TimelinePlaneMark from "./TimelinePlaneMark";
 
 type TimelineEvent = {
   year: string;
@@ -7,23 +8,43 @@ type TimelineEvent = {
   icon?: string;
 };
 
+// Positional map of event index → country the subject is *in* at that event.
+// Order is locked to the `about.timelineEvents` array in messages/*.json.
 const locationByIndex: Array<"china" | "japan" | undefined> = [
-  "china", "japan", "china", "japan", "china", "japan", "japan",
+  "china", "japan", "china", "japan", "china", "japan", "japan", "japan",
 ];
 
 const TimelineSection = async () => {
   const t = await getTranslations("about");
   const locationsT = await getTranslations("locations");
 
+  // Direction is derived only from plane events themselves: it encodes where
+  // the subject is going *at that event*. "east" = heading to Japan, "west"
+  // = heading to China. Non-plane rows have no direction even if the
+  // location meta differs from the previous row.
   const events = (t.raw("timelineEvents") as TimelineEvent[]).map(
-    (event, index) => ({
-      ...event,
-      location: locationByIndex[index],
-      special:
-        event.icon === "rocket" ||
-        event.icon === "university" ||
-        event.icon === "graduation",
-    }),
+    (event, index) => {
+      const location = locationByIndex[index];
+      const direction: "east" | "west" | undefined =
+        event.icon === "plane"
+          ? location === "japan"
+            ? "east"
+            : location === "china"
+              ? "west"
+              : undefined
+          : undefined;
+      const hasPlane = event.icon === "plane" && direction !== undefined;
+      return {
+        ...event,
+        location,
+        direction,
+        hasPlane,
+        special:
+          event.icon === "rocket" ||
+          event.icon === "university" ||
+          event.icon === "graduation",
+      };
+    },
   );
 
   return (
@@ -38,12 +59,15 @@ const TimelineSection = async () => {
             key={index}
             className="grid grid-cols-[5rem_1fr] sm:grid-cols-[8rem_1fr] gap-4 sm:gap-10 py-6"
           >
-            <div>
+            <div className="flex flex-col">
               <p className="meta text-[color:var(--color-ink)]">{event.year}</p>
               {event.location && (
                 <p className="meta mt-1 opacity-70">
                   {locationsT(event.location)}
                 </p>
+              )}
+              {event.hasPlane && event.direction && (
+                <TimelinePlaneMark direction={event.direction} />
               )}
             </div>
             <div>


### PR DESCRIPTION
## Summary
Restore the pre-Phase-1 plane animation on the three travel rows (1999 来日, 2009 中国帰国, 2021 再来日) in the About → Timeline section, rebuilt in the Editorial Academic vocabulary.

- New client leaf `src/components/TimelinePlaneMark.tsx`: decorative stroke-only plane glyph (teal ink, 1.25px hairline, viewBox 28×24), one-shot `IntersectionObserver` driving CSS transitions on `opacity`, `transform`, and `stroke-dashoffset`. No framer-motion.
- `TimelineSection.tsx` enriches each event with a typed `direction: "east" | "west" | undefined` derived solely from plane events' destinations, and mounts the mark only when `event.icon === "plane"`.
- Adjacent: `locationByIndex` had 7 entries for 8 timelineEvents — appended `"japan"` for the 2023 博士課程入学 row so its location meta now renders.

## Design rationale (co-designed with Codex)
Three directions were considered (A: line-draw only, B: directional settle only, C: cross-row trajectory arcs). Picked **hybrid A+B**: a directional settle (±18 px translate, ±4° rotation) plus a short line-draw reveal on the glyph itself. Keeps the "crossing borders" narrative, reads as paper-and-ink, no pictogram, no loops, no bounce.

## What it looks like
- Small teal glyph in the year-gutter, below the location meta. Faces the direction of travel (east = to Japan, west = to China). `aria-hidden`, no focus target.
- Animates in once on first intersection; never retriggers.
- `prefers-reduced-motion` honoured twice: `matchMedia` short-circuit in the leaf + the existing global reset in `globals.css`.

## Test plan
- [x] `npm run build` clean; lint clean.
- [x] Computed-style sweep on `#about`: **3** plane SVGs present, still **0** gradients, **0** rounded cards ≥ 8px, **0** box-shadows.
- [x] Scroll verification: wrapper transitions from `opacity:0`, `translateX(±18px) rotate(±4deg)` to `opacity:1`, `translateX(0) rotate(0)` on intersection. Disconnects after one shot.
- [x] Direction verification: 1999/2021 enter from the left (east), 2009 enters from the right (west).
- [ ] Reviewer: test with `prefers-reduced-motion: reduce` emulation — planes should appear statically.
- [ ] Reviewer: mobile width (375×667) — plane stays inside the 5 rem gutter and does not overlap the title/description column.

## Bundle
`/[locale]` shipped 8.52 kB → **9.11 kB** (+0.59 kB), First Load JS 136 → **137 kB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)