### PR TITLE
Add Springer Nature book chapter to Research section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -124,6 +124,23 @@
     "conferencePresentations": "Conference Presentations",
     "academicResearch": "Academic Research",
     "doi": "DOI →",
+    "books": "Books",
+    "bookChapter": "Book Chapter",
+    "ebookIsbn": "eBook ISBN",
+    "printIsbn": "Print ISBN",
+    "viewOnSpringer": "View on Springer Nature Link",
+    "booksList": [
+      {
+        "authors": "Liang, Z. (contributing author)",
+        "year": "2026",
+        "title": "English Language Education: Current Issues and Future Prospects I",
+        "publisher": "Springer Nature Singapore",
+        "role": "bookChapter",
+        "isbn": "978-981-95-6163-6",
+        "printIsbn": "978-981-95-6162-9",
+        "link": "https://link.springer.com/book/10.1007/978-981-95-6163-6"
+      }
+    ],
     "peerReviewedList": [
       {
         "authors": "Wang, F., Kanamaru, T., & Liang, Z.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -124,6 +124,23 @@
     "conferencePresentations": "学会発表",
     "academicResearch": "学術研究",
     "doi": "DOI →",
+    "books": "著書",
+    "bookChapter": "分担執筆",
+    "ebookIsbn": "電子書籍 ISBN",
+    "printIsbn": "印刷版 ISBN",
+    "viewOnSpringer": "Springer Nature Link で見る",
+    "booksList": [
+      {
+        "authors": "梁 震（分担執筆）",
+        "year": "2026",
+        "title": "英語教育：現状の課題と将来展望 I",
+        "publisher": "シュプリンガー・ネイチャー（シンガポール）",
+        "role": "bookChapter",
+        "isbn": "978-981-95-6163-6",
+        "printIsbn": "978-981-95-6162-9",
+        "link": "https://link.springer.com/book/10.1007/978-981-95-6163-6"
+      }
+    ],
     "peerReviewedList": [
       {
         "authors": "王 芳, 金丸 敏幸, 梁 震",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -124,6 +124,23 @@
     "conferencePresentations": "学术会议报告",
     "academicResearch": "研究成果",
     "doi": "DOI →",
+    "books": "著作",
+    "bookChapter": "分担执笔",
+    "ebookIsbn": "电子书 ISBN",
+    "printIsbn": "纸质版 ISBN",
+    "viewOnSpringer": "在 Springer Nature Link 上查看",
+    "booksList": [
+      {
+        "authors": "梁震（分担执笔）",
+        "year": "2026",
+        "title": "英语教育：现状的课题与未来展望 I",
+        "publisher": "施普林格·自然（新加坡）",
+        "role": "bookChapter",
+        "isbn": "978-981-95-6163-6",
+        "printIsbn": "978-981-95-6162-9",
+        "link": "https://link.springer.com/book/10.1007/978-981-95-6163-6"
+      }
+    ],
     "peerReviewedList": [
       {
         "authors": "王芳, 金丸敏幸, 梁震",

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { m } from "framer-motion";
 import { useInView } from "react-intersection-observer";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, BookOpen } from "lucide-react";
 
 type Publication = {
   authors: string;
@@ -36,6 +36,19 @@ type ConferenceListItem = {
   link?: string;
 };
 
+type BookListItem = {
+  authors: string;
+  year: string | number;
+  title: string;
+  publisher: string;
+  role?: string;
+  isbn?: string;
+  printIsbn?: string;
+  link?: string;
+};
+
+type Book = BookListItem & { year: number };
+
 const ResearchSection = () => {
   const t = useTranslations("research");
   const pubT = useTranslations("publications");
@@ -48,6 +61,12 @@ const ResearchSection = () => {
   const conferencePresentations = t.raw(
     "conferencePresentationsList",
   ) as ConferenceListItem[];
+  const booksRaw = t.raw("booksList") as BookListItem[] | undefined;
+
+  const books: Book[] = (booksRaw ?? [])
+    .map((item) => ({ ...item, year: Number(item.year) }))
+    .filter((b) => Number.isFinite(b.year))
+    .sort((a, b) => b.year - a.year);
 
   const publications: Publication[] = [
     ...peerReviewed.map((item) => ({
@@ -116,6 +135,90 @@ const ResearchSection = () => {
           </p>
         </div>
 
+
+        {/* Books */}
+        {books.length > 0 && (
+          <m.div
+            initial={{ opacity: 0 }}
+            animate={inView ? { opacity: 1 } : { opacity: 0 }}
+            transition={{ delay: 0.2 }}
+            className="mt-12"
+          >
+            <h3 className="text-3xl font-bold text-slate-800 dark:text-white mb-12 text-center">
+              {t("books")}
+            </h3>
+
+            <m.div
+              variants={containerVariants}
+              initial="hidden"
+              animate={inView ? "visible" : "hidden"}
+              className="space-y-6 max-w-4xl mx-auto"
+            >
+              {books.map((book, index) => (
+                <m.div
+                  key={`book-${index}`}
+                  variants={itemVariants}
+                  className="bg-gradient-to-br from-amber-50/70 to-orange-50/40 dark:from-amber-900/10 dark:to-orange-900/5 rounded-xl p-6 border border-amber-200/60 dark:border-amber-800/40 hover:border-amber-300 dark:hover:border-amber-700 transition-colors duration-200"
+                >
+                  <div className="flex items-start justify-between flex-wrap gap-2">
+                    <div className="flex items-start gap-3 flex-1">
+                      <BookOpen className="text-amber-600 dark:text-amber-400 mt-1 flex-shrink-0" size={22} />
+                      <h3 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-white flex-1">
+                        {book.title}
+                      </h3>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium px-3 py-1 rounded-full text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/30">
+                        {book.year}
+                      </span>
+                      {book.role && (
+                        <span className="text-xs px-2 py-1 bg-amber-100/70 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 rounded">
+                          {t(book.role)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 pl-9">
+                    {book.authors}
+                  </p>
+
+                  <p className="text-sm text-gray-700 dark:text-gray-300 mt-1 italic pl-9">
+                    {book.publisher}
+                  </p>
+
+                  {(book.isbn || book.printIsbn) && (
+                    <div className="mt-2 pl-9 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                      {book.isbn && (
+                        <span>
+                          <span className="font-medium">{t("ebookIsbn")}:</span> {book.isbn}
+                        </span>
+                      )}
+                      {book.printIsbn && (
+                        <span>
+                          <span className="font-medium">{t("printIsbn")}:</span> {book.printIsbn}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {book.link && (
+                    <div className="mt-3 pl-9">
+                      <a
+                        href={book.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-amber-700 dark:text-amber-400 hover:underline inline-flex items-center gap-1"
+                      >
+                        {t("viewOnSpringer")} <ExternalLink size={14} />
+                      </a>
+                    </div>
+                  )}
+                </m.div>
+              ))}
+            </m.div>
+          </m.div>
+        )}
 
         {/* Publications */}
         <m.div


### PR DESCRIPTION
## Summary
- 新規業績として、分担執筆した Springer Nature 電子書籍『英語教育：現状の課題と将来展望 I』を Research セクションに反映
- 既存の Publications リストには混ぜず、独立した **Books サブセクション**を Publications の上に追加（amber 配色・BookOpen アイコン・eBook/Print 両 ISBN 表示・Springer Nature Link CTA ボタン）
- `messages/{ja,en,zh}.json` の `research` 配下に `books` / `bookChapter` / `ebookIsbn` / `printIsbn` / `viewOnSpringer` ラベル＋ `booksList[]` を 3 ロケール分追加
- タイトル・著者・出版社表記は各ロケールに訳し分け。書籍 URL は ISBN から Springer Nature Link の標準形式で生成

## Book Metadata
- Title: 英語教育：現状の課題と将来展望 I / English Language Education: Current Issues and Future Prospects I / 英语教育：现状的课题与未来展望 I
- Publisher: Springer Nature Singapore
- eBook ISBN: 978-981-95-6163-6 / Print ISBN: 978-981-95-6162-9
- Year: 2026 (暫定)
- Role: Book Chapter (分担執筆 / 分担执笔)
- Link: https://link.springer.com/book/10.1007/978-981-95-6163-6

## Test plan
- [x] `npm run lint` pass
- [x] `npm run build` pass (型エラーなし)
- [x] `/ja` の Research セクションに著書カードが Publications の上に表示される
- [x] `/en` で "Books" 見出し・"Book Chapter" バッジ・"View on Springer Nature Link" が正しく出る
- [x] `/zh` で "著作"・"分担执笔"・"在 Springer Nature Link 上查看" が正しく出る
- [x] amber バッジ・カード背景がライト/ダーク両モードで視認可能
- [ ] 本人が出版年・章タイトル・共著者を差し替える（メタデータ更新のみ、再デプロイで反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)