### PR TITLE
fix: スキル・技術セクションの虚偽情報を削除し他セクションと整合させる

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -533,28 +533,19 @@
   },
   "skills": {
     "title": "Skills & Stack",
-    "subtitle": "Technologies used in production, grouped by proficiency",
+    "subtitle": "Technologies I've used across work, research, and personal projects, grouped by proficiency",
     "kicker": "Stack",
     "programming": "Programming Languages",
     "frontend": "Frontend",
     "backend": "Backend",
     "database": "Databases",
-    "mobile": "Mobile",
     "infrastructure": "Infrastructure",
-    "cloud": "Cloud & Infra",
-    "ai": "AI & Tools",
+    "ai": "AI & Machine Learning",
+    "tools": "Tools",
     "languages": "Languages",
-    "jobTitle": "PhD & Researcher",
-    "ceoFounder": "CEO & Founder",
-    "yearsExperience": "{years}+ years experience",
-    "yearsLabel": "y",
     "levelCore": "Core",
     "levelProficient": "Proficient",
     "levelFamiliar": "Familiar",
-    "mainFeatures": "Key Features",
-    "techStack": "Tech Stack",
-    "proficiency": "Proficiency",
-    "technicalExpertise": "Technical Expertise",
     "categories": [
       {
         "id": "languages",
@@ -562,78 +553,113 @@
         "items": [
           {
             "name": "JavaScript",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "TypeScript",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Python",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Swift",
-            "years": 4
+            "level": "proficient"
           },
           {
             "name": "PHP",
-            "years": 3
-          },
-          {
-            "name": "C",
-            "years": 2
+            "level": "proficient"
           }
         ]
       },
       {
-        "id": "frameworks",
+        "id": "frontend",
         "titleKey": "frontend",
         "items": [
           {
             "name": "React",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Next.js",
-            "featured": true
+            "level": "core"
+          },
+          {
+            "name": "Tailwind CSS",
+            "level": "proficient"
           },
           {
             "name": "React Native",
-            "years": 2
-          },
-          {
-            "name": "Node.js / Express"
-          },
+            "level": "familiar"
+          }
+        ]
+      },
+      {
+        "id": "backend",
+        "titleKey": "backend",
+        "items": [
           {
             "name": "FastAPI",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "LangChain"
+            "name": "Node.js / Express",
+            "level": "proficient"
           },
+          {
+            "name": "WordPress",
+            "level": "proficient"
+          }
+        ]
+      },
+      {
+        "id": "ai",
+        "titleKey": "ai",
+        "items": [
           {
             "name": "LangGraph",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "Transformers"
+            "name": "LangChain",
+            "level": "proficient"
           },
           {
-            "name": "PyTorch"
+            "name": "PyTorch",
+            "level": "proficient"
           },
           {
-            "name": "DeepSpeed"
+            "name": "Transformers",
+            "level": "proficient"
           },
           {
-            "name": "Dify"
+            "name": "DeepSpeed",
+            "level": "proficient"
           },
           {
-            "name": "WordPress"
+            "name": "LoRA",
+            "level": "proficient"
+          },
+          {
+            "name": "Dify",
+            "level": "proficient"
+          },
+          {
+            "name": "Scikit-learn",
+            "level": "proficient"
+          },
+          {
+            "name": "Word2Vec / gensim",
+            "level": "proficient"
+          },
+          {
+            "name": "MeCab",
+            "level": "proficient"
+          },
+          {
+            "name": "Jupyter",
+            "level": "proficient"
           }
         ]
       },
@@ -642,91 +668,68 @@
         "titleKey": "database",
         "items": [
           {
-            "name": "MariaDB / MySQL",
-            "years": 5
+            "name": "PostgreSQL",
+            "level": "core"
           },
           {
-            "name": "PostgreSQL",
-            "years": 3,
-            "featured": true
+            "name": "MariaDB / MySQL",
+            "level": "proficient"
+          },
+          {
+            "name": "AWS Aurora",
+            "level": "proficient"
           },
           {
             "name": "MongoDB",
-            "years": 2
-          },
-          {
-            "name": "AWS Aurora"
+            "level": "familiar"
           }
         ]
       },
       {
         "id": "infra",
-        "titleKey": "cloud",
+        "titleKey": "infrastructure",
         "items": [
           {
-            "name": "Nginx",
-            "years": 6
+            "name": "AWS",
+            "level": "core"
           },
           {
-            "name": "Apache",
-            "years": 5
+            "name": "Vercel",
+            "level": "proficient"
+          },
+          {
+            "name": "Docker",
+            "level": "proficient"
           },
           {
             "name": "Linux",
-            "years": 5
+            "level": "proficient"
+          },
+          {
+            "name": "Nginx",
+            "level": "proficient"
+          },
+          {
+            "name": "Apache",
+            "level": "proficient"
           },
           {
             "name": "Caddy",
-            "years": 3
-          },
-          {
-            "name": "AWS",
-            "years": 3,
-            "featured": true
-          },
-          {
-            "name": "Vercel"
-          },
-          {
-            "name": "Docker"
+            "level": "proficient"
           }
         ]
       },
       {
         "id": "tools",
-        "titleKey": "ai",
+        "titleKey": "tools",
         "items": [
           {
             "name": "Git",
-            "years": 5
+            "level": "proficient"
           },
           {
-            "name": "Scikit-learn",
-            "years": 3
-          },
-          {
-            "name": "Word2Vec / gensim"
-          },
-          {
-            "name": "Jupyter"
-          },
-          {
-            "name": "Jest"
-          },
-          {
-            "name": "Figma"
-          },
-          {
-            "name": "Webpack"
-          },
-          {
-            "name": "PDF.js"
-          },
-          {
-            "name": "MeCab"
-          },
-          {
-            "name": "BERT"
+            "name": "Figma",
+            "level": "proficient"
           }
         ]
       }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -533,28 +533,19 @@
   },
   "skills": {
     "title": "スキル・技術",
-    "subtitle": "業務で扱った技術スタック（習熟度別）",
+    "subtitle": "業務・研究・個人開発で扱ってきた技術スタック（習熟度別）",
     "kicker": "Stack",
     "programming": "プログラミング言語",
     "frontend": "フロントエンド",
     "backend": "バックエンド",
     "database": "データベース",
-    "mobile": "モバイル開発",
     "infrastructure": "インフラ",
-    "cloud": "クラウド",
     "ai": "AI・機械学習",
+    "tools": "開発ツール",
     "languages": "言語能力",
-    "jobTitle": "博士・研究者",
-    "ceoFounder": "CEO・創業者",
-    "yearsExperience": "{years}年以上の経験",
-    "yearsLabel": "y",
     "levelCore": "主力",
     "levelProficient": "実務レベル",
     "levelFamiliar": "経験あり",
-    "mainFeatures": "主な機能・特徴",
-    "techStack": "技術スタック",
-    "proficiency": "習熟度",
-    "technicalExpertise": "技術的専門性",
     "categories": [
       {
         "id": "languages",
@@ -562,78 +553,113 @@
         "items": [
           {
             "name": "JavaScript",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "TypeScript",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Python",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Swift",
-            "years": 4
+            "level": "proficient"
           },
           {
             "name": "PHP",
-            "years": 3
-          },
-          {
-            "name": "C",
-            "years": 2
+            "level": "proficient"
           }
         ]
       },
       {
-        "id": "frameworks",
+        "id": "frontend",
         "titleKey": "frontend",
         "items": [
           {
             "name": "React",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Next.js",
-            "featured": true
+            "level": "core"
+          },
+          {
+            "name": "Tailwind CSS",
+            "level": "proficient"
           },
           {
             "name": "React Native",
-            "years": 2
-          },
-          {
-            "name": "Node.js / Express"
-          },
+            "level": "familiar"
+          }
+        ]
+      },
+      {
+        "id": "backend",
+        "titleKey": "backend",
+        "items": [
           {
             "name": "FastAPI",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "LangChain"
+            "name": "Node.js / Express",
+            "level": "proficient"
           },
+          {
+            "name": "WordPress",
+            "level": "proficient"
+          }
+        ]
+      },
+      {
+        "id": "ai",
+        "titleKey": "ai",
+        "items": [
           {
             "name": "LangGraph",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "Transformers"
+            "name": "LangChain",
+            "level": "proficient"
           },
           {
-            "name": "PyTorch"
+            "name": "PyTorch",
+            "level": "proficient"
           },
           {
-            "name": "DeepSpeed"
+            "name": "Transformers",
+            "level": "proficient"
           },
           {
-            "name": "Dify"
+            "name": "DeepSpeed",
+            "level": "proficient"
           },
           {
-            "name": "WordPress"
+            "name": "LoRA",
+            "level": "proficient"
+          },
+          {
+            "name": "Dify",
+            "level": "proficient"
+          },
+          {
+            "name": "Scikit-learn",
+            "level": "proficient"
+          },
+          {
+            "name": "Word2Vec / gensim",
+            "level": "proficient"
+          },
+          {
+            "name": "MeCab",
+            "level": "proficient"
+          },
+          {
+            "name": "Jupyter",
+            "level": "proficient"
           }
         ]
       },
@@ -642,91 +668,68 @@
         "titleKey": "database",
         "items": [
           {
-            "name": "MariaDB / MySQL",
-            "years": 5
+            "name": "PostgreSQL",
+            "level": "core"
           },
           {
-            "name": "PostgreSQL",
-            "years": 3,
-            "featured": true
+            "name": "MariaDB / MySQL",
+            "level": "proficient"
+          },
+          {
+            "name": "AWS Aurora",
+            "level": "proficient"
           },
           {
             "name": "MongoDB",
-            "years": 2
-          },
-          {
-            "name": "AWS Aurora"
+            "level": "familiar"
           }
         ]
       },
       {
         "id": "infra",
-        "titleKey": "cloud",
+        "titleKey": "infrastructure",
         "items": [
           {
-            "name": "Nginx",
-            "years": 6
+            "name": "AWS",
+            "level": "core"
           },
           {
-            "name": "Apache",
-            "years": 5
+            "name": "Vercel",
+            "level": "proficient"
+          },
+          {
+            "name": "Docker",
+            "level": "proficient"
           },
           {
             "name": "Linux",
-            "years": 5
+            "level": "proficient"
+          },
+          {
+            "name": "Nginx",
+            "level": "proficient"
+          },
+          {
+            "name": "Apache",
+            "level": "proficient"
           },
           {
             "name": "Caddy",
-            "years": 3
-          },
-          {
-            "name": "AWS",
-            "years": 3,
-            "featured": true
-          },
-          {
-            "name": "Vercel"
-          },
-          {
-            "name": "Docker"
+            "level": "proficient"
           }
         ]
       },
       {
         "id": "tools",
-        "titleKey": "ai",
+        "titleKey": "tools",
         "items": [
           {
             "name": "Git",
-            "years": 5
+            "level": "proficient"
           },
           {
-            "name": "Scikit-learn",
-            "years": 3
-          },
-          {
-            "name": "Word2Vec / gensim"
-          },
-          {
-            "name": "Jupyter"
-          },
-          {
-            "name": "Jest"
-          },
-          {
-            "name": "Figma"
-          },
-          {
-            "name": "Webpack"
-          },
-          {
-            "name": "PDF.js"
-          },
-          {
-            "name": "MeCab"
-          },
-          {
-            "name": "BERT"
+            "name": "Figma",
+            "level": "proficient"
           }
         ]
       }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -533,28 +533,19 @@
   },
   "skills": {
     "title": "技能与技术栈",
-    "subtitle": "实际生产中使用的技术栈（按熟练度分组）",
+    "subtitle": "在工作、研究与个人开发中使用过的技术栈（按熟练度分组）",
     "kicker": "Stack",
     "programming": "编程语言",
     "frontend": "前端",
     "backend": "后端",
     "database": "数据库",
-    "mobile": "移动开发",
     "infrastructure": "基础设施",
-    "cloud": "云与基础设施",
-    "ai": "AI 与工具",
+    "ai": "AI·机器学习",
+    "tools": "开发工具",
     "languages": "语言能力",
-    "jobTitle": "博士・研究者",
-    "ceoFounder": "CEO・创始人",
-    "yearsExperience": "{years}年以上经验",
-    "yearsLabel": "y",
     "levelCore": "主力",
     "levelProficient": "熟练",
     "levelFamiliar": "了解",
-    "mainFeatures": "主要功能・特点",
-    "techStack": "技术栈",
-    "proficiency": "熟练度",
-    "technicalExpertise": "技术专长",
     "categories": [
       {
         "id": "languages",
@@ -562,78 +553,113 @@
         "items": [
           {
             "name": "JavaScript",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "TypeScript",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Python",
-            "years": 5,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Swift",
-            "years": 4
+            "level": "proficient"
           },
           {
             "name": "PHP",
-            "years": 3
-          },
-          {
-            "name": "C",
-            "years": 2
+            "level": "proficient"
           }
         ]
       },
       {
-        "id": "frameworks",
+        "id": "frontend",
         "titleKey": "frontend",
         "items": [
           {
             "name": "React",
-            "years": 3,
-            "featured": true
+            "level": "core"
           },
           {
             "name": "Next.js",
-            "featured": true
+            "level": "core"
+          },
+          {
+            "name": "Tailwind CSS",
+            "level": "proficient"
           },
           {
             "name": "React Native",
-            "years": 2
-          },
-          {
-            "name": "Node.js / Express"
-          },
+            "level": "familiar"
+          }
+        ]
+      },
+      {
+        "id": "backend",
+        "titleKey": "backend",
+        "items": [
           {
             "name": "FastAPI",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "LangChain"
+            "name": "Node.js / Express",
+            "level": "proficient"
           },
+          {
+            "name": "WordPress",
+            "level": "proficient"
+          }
+        ]
+      },
+      {
+        "id": "ai",
+        "titleKey": "ai",
+        "items": [
           {
             "name": "LangGraph",
-            "featured": true
+            "level": "core"
           },
           {
-            "name": "Transformers"
+            "name": "LangChain",
+            "level": "proficient"
           },
           {
-            "name": "PyTorch"
+            "name": "PyTorch",
+            "level": "proficient"
           },
           {
-            "name": "DeepSpeed"
+            "name": "Transformers",
+            "level": "proficient"
           },
           {
-            "name": "Dify"
+            "name": "DeepSpeed",
+            "level": "proficient"
           },
           {
-            "name": "WordPress"
+            "name": "LoRA",
+            "level": "proficient"
+          },
+          {
+            "name": "Dify",
+            "level": "proficient"
+          },
+          {
+            "name": "Scikit-learn",
+            "level": "proficient"
+          },
+          {
+            "name": "Word2Vec / gensim",
+            "level": "proficient"
+          },
+          {
+            "name": "MeCab",
+            "level": "proficient"
+          },
+          {
+            "name": "Jupyter",
+            "level": "proficient"
           }
         ]
       },
@@ -642,91 +668,68 @@
         "titleKey": "database",
         "items": [
           {
-            "name": "MariaDB / MySQL",
-            "years": 5
+            "name": "PostgreSQL",
+            "level": "core"
           },
           {
-            "name": "PostgreSQL",
-            "years": 3,
-            "featured": true
+            "name": "MariaDB / MySQL",
+            "level": "proficient"
+          },
+          {
+            "name": "AWS Aurora",
+            "level": "proficient"
           },
           {
             "name": "MongoDB",
-            "years": 2
-          },
-          {
-            "name": "AWS Aurora"
+            "level": "familiar"
           }
         ]
       },
       {
         "id": "infra",
-        "titleKey": "cloud",
+        "titleKey": "infrastructure",
         "items": [
           {
-            "name": "Nginx",
-            "years": 6
+            "name": "AWS",
+            "level": "core"
           },
           {
-            "name": "Apache",
-            "years": 5
+            "name": "Vercel",
+            "level": "proficient"
+          },
+          {
+            "name": "Docker",
+            "level": "proficient"
           },
           {
             "name": "Linux",
-            "years": 5
+            "level": "proficient"
+          },
+          {
+            "name": "Nginx",
+            "level": "proficient"
+          },
+          {
+            "name": "Apache",
+            "level": "proficient"
           },
           {
             "name": "Caddy",
-            "years": 3
-          },
-          {
-            "name": "AWS",
-            "years": 3,
-            "featured": true
-          },
-          {
-            "name": "Vercel"
-          },
-          {
-            "name": "Docker"
+            "level": "proficient"
           }
         ]
       },
       {
         "id": "tools",
-        "titleKey": "ai",
+        "titleKey": "tools",
         "items": [
           {
             "name": "Git",
-            "years": 5
+            "level": "proficient"
           },
           {
-            "name": "Scikit-learn",
-            "years": 3
-          },
-          {
-            "name": "Word2Vec / gensim"
-          },
-          {
-            "name": "Jupyter"
-          },
-          {
-            "name": "Jest"
-          },
-          {
-            "name": "Figma"
-          },
-          {
-            "name": "Webpack"
-          },
-          {
-            "name": "PDF.js"
-          },
-          {
-            "name": "MeCab"
-          },
-          {
-            "name": "BERT"
+            "name": "Figma",
+            "level": "proficient"
           }
         ]
       }

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -21,13 +21,6 @@ const SkillsSection = async () => {
     (a, b) => (parseInt(b.date, 10) || 0) - (parseInt(a.date, 10) || 0),
   );
 
-  // Group skills by proficiency instead of showing cryptic "5y" badges / an
-  // unexplained blue accent. Tier is derived from the existing data: featured
-  // skills are "core", anything with ≥3 years is "proficient", the rest are
-  // "familiar". The tier label carries the meaning; chips stay monochrome.
-  type SkillItem = SkillCategory["items"][number];
-  const levelOf = (i: SkillItem): "core" | "proficient" | "familiar" =>
-    i.featured ? "core" : (i.years ?? 0) >= 3 ? "proficient" : "familiar";
   const tiers = [
     { key: "core", label: t("levelCore") },
     { key: "proficient", label: t("levelProficient") },
@@ -58,7 +51,7 @@ const SkillsSection = async () => {
               <div className="space-y-5 min-w-0">
                 {tiers.map((tier) => {
                   const items = cat.items.filter(
-                    (i) => levelOf(i) === tier.key,
+                    (i) => i.level === tier.key,
                   );
                   if (items.length === 0) return null;
                   return (

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -43,12 +43,18 @@ export interface HighlightStat {
 }
 
 export interface SkillCategory {
-  id: "languages" | "frameworks" | "databases" | "infra" | "tools";
-  titleKey: "programming" | "frontend" | "backend" | "database" | "cloud" | "ai";
+  id: "languages" | "frontend" | "backend" | "ai" | "databases" | "infra" | "tools";
+  titleKey:
+    | "programming"
+    | "frontend"
+    | "backend"
+    | "database"
+    | "ai"
+    | "infrastructure"
+    | "tools";
   items: Array<{
     name: string;
-    years?: number;
-    featured?: boolean;
+    level: "core" | "proficient" | "familiar";
   }>;
 }
 


### PR DESCRIPTION
## 概要

スキル・技術セクション（`messages/{ja,en,zh}.json` の `skills`）に、職務経歴・プロフィール・プロジェクト等の他セクションと矛盾する虚偽情報や構造バグがあったため、本人ヒアリングに基づいて修正した。

## 変更内容

### 虚偽情報の削除

- 経験のない技術項目を削除: **C / Jest / Webpack / PDF.js / BERT**
- 虚偽・未使用の残骸キーを削除: `ceoFounder`（「CEO・創業者」）, `jobTitle`, `yearsExperience`, `yearsLabel`, `mainFeatures`, `techStack`, `proficiency`, `technicalExpertise`, `mobile`, `cloud`
- 画面に表示されず tier 振り分けにだけ使われていた不正確な経験年数データ（Nginx 6年 > JavaScript 5年 など）を廃止し、明示的な `level`（`core` / `proficient` / `familiar`）に置き換え

### 構造バグの修正

- `tools` カテゴリが「AI・機械学習」見出しを借用し、Git / Figma が AI 見出しの下に表示されていた問題を解消
- `frameworks` カテゴリが「フロントエンド」見出しなのに FastAPI / PyTorch / DeepSpeed 等を含んでいた問題を解消
- カテゴリを 7 つに再編成: プログラミング言語 / フロントエンド / バックエンド / AI・機械学習 / データベース / インフラ / 開発ツール（`tools` 見出しキーを新規追加）
- en の見出し "AI & Tools" → "AI & Machine Learning"（zh も同様）

### 漏れていた技術の追加

- **Tailwind CSS**（SUIREN・本サイト自体で使用）
- **LoRA**（medimo の ASR 微調整）

### 習熟度の再設定（裏付けベース）

| tier | 基準 |
|---|---|
| 主力 | 職歴 stack で中心的な 9 つ（JS / TS / Python / React / Next.js / FastAPI / LangGraph / PostgreSQL / AWS） |
| 実務レベル | 職歴 stack に登場、または本人申告 3 年以上（Swift, PHP, Nginx 等） |
| 経験あり | 本人申告 3 年未満（React Native, MongoDB） |

subtitle も「業務で扱った〜」→「業務・研究・個人開発で扱ってきた〜」に変更（Swift / Nginx 等はサイト記載の職歴外の経験のため）。

## 変更ファイル

- `messages/{ja,en,zh}.json` — `skills` 名前空間（3 ロケール同一構造）
- `src/types/content.ts` — `SkillCategory` の `id` / `titleKey` / `items` 型を新データ形に更新
- `src/components/SkillsSection.tsx` — years/featured からの tier 導出を削除し `item.level` を直接参照

## 検証

- [x] `npm run test`（34 件 pass — 3 ロケールのキー構造・配列長一致を含む）
- [x] `npm run typecheck` / `npm run lint`
- [x] `npm run build`
- [x] Playwright で ja/en/zh のスキルセクションを目視確認（削除 5 項目の消失、Tailwind CSS / LoRA の表示、AI 見出し下に Git/Figma がいないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
