### PR TITLE
fix: ヒーローCTAがプロフィールを飛ばす問題を解消（#about誘導＋成果は抜け道に降格）

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,7 @@
     "subtitle": "Research. Build. Ship. All through language.",
     "description": "PhD, Kyoto University",
     "currentlyAt": "GMO Pepabo / Engineer",
+    "learnMore": "Learn more",
     "viewWork": "See the results",
     "role": "ML Engineer & Researcher",
     "metaNow": "Now",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -31,6 +31,7 @@
     "subtitle": "研究する。つくる。動かす。すべて、ことばで。",
     "description": "京都大学 博士号取得",
     "currentlyAt": "GMO ペパボ ／ エンジニア",
+    "learnMore": "もっと知る",
     "viewWork": "成果を見る",
     "role": "ML エンジニア ・ 研究者",
     "metaNow": "現職",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -31,6 +31,7 @@
     "subtitle": "研究、构建、落地——皆围绕语言。",
     "description": "京都大学博士",
     "currentlyAt": "GMO Pepabo ／ 工程师",
+    "learnMore": "了解更多",
     "viewWork": "查看成果",
     "role": "ML 工程师 ・ 研究者",
     "metaNow": "现职",

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { getLocale, getTranslations } from "next-intl/server";
 import {
   LuArrowDown as ArrowDown,
+  LuArrowRight as ArrowRight,
   LuArrowUpRight as ArrowUpRight,
 } from "react-icons/lu";
 import { FaEnvelope, FaGithub } from "react-icons/fa";
@@ -15,7 +16,10 @@ import { formatRelativeTime } from "@/lib/relativeTime";
  * - The kanji brand mark「梁 震」is the single fixed h1 in display mincho;
  *   the other readings live in a permanent small meta line (no rotation,
  *   no timers, no CLS reservations, stable LCP).
- * - Left column: identity + tagline + CTA. Right column: a bottom-aligned
+ * - Left column: identity + tagline + CTAs (primary → #about so the visitor
+ *   continues the page's narrative order instead of skipping the profile;
+ *   a subordinate text link → #highlights stays as a shortcut to the numbers).
+ *   Right column: a bottom-aligned
  *   fact list (current role / degree / primary contacts).
  * - The full 12-icon SocialLinks live in the ContactModal — the #contact hash
  *   opens it (plain anchor keeps this a Server Component).
@@ -99,10 +103,20 @@ const HeroSection = async ({
             {t("subtitle")}
           </p>
 
-          <a href="#highlights" className="btn-pill">
-            {t("viewWork")}
-            <ArrowDown size={16} aria-hidden />
-          </a>
+          {/* プライマリは物語順の次（about=プロフィール）へ降ろす。下矢印は
+              「すぐ下の次セクションへ」を表す。成果(#highlights)へ飛ばすと
+              about を読み飛ばしてしまうため、それは控えめなセカンダリの
+              テキストリンク（抜け道）に降格する。 */}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+            <a href="#about" className="btn-pill">
+              {t("learnMore")}
+              <ArrowDown size={16} aria-hidden />
+            </a>
+            <a href="#highlights" className="link-accent">
+              {t("viewWork")}
+              <ArrowRight size={16} aria-hidden />
+            </a>
+          </div>
         </div>
 
         {/* Fact column — bottom-aligned against the identity block */}


### PR DESCRIPTION
## 何を直すか

ヒーローのプライマリCTA「成果を見る」が `#highlights` に**直行**し、DOM順でその手前にある **about（プロフィール）を読み飛ばして**いた。

`page.tsx` は「自己紹介(about)→数字で見る成果(highlights)→経歴…と、初見でも文脈が積み上がる物語順」と設計意図を宣言しているのに、唯一のCTAがその物語を壊して数字セクションへワープしていた。オーナーの不満「ボタンを押すとプロフィールが見られず飛ばされる」の正体はこれ。

## どう直したか

ボタン設計を **subagent 3人（UX/IA・ビジュアルデザイン・訪問者意図）** で検討し、結論を統合した。

| | Before | After |
|---|---|---|
| プライマリ | 塗りピル「成果を見る」→ `#highlights`（aboutを飛ばす） | 塗りピル「もっと知る」→ `#about`（物語順の次へ降りる） |
| セカンダリ | なし | テキストリンク「成果を見る」→ `#highlights`（抜け道） |
| 下矢印の意味 | 矛盾（飛ぶのに「下」） | 一致（すぐ下の次セクションへ降りる） |

- **プライマリを `#about` に。** これで「プロフィールを飛ばす」が構造的に消える（押すと profile に着地する）。`about` は `SECTION_IDS` にあり scroll-spy/リダイレクト済みなので 404 リスクなし。
- **成果(#highlights)は控えめなテキストリンクにセカンダリ降格。** せっかちな評価者向けの抜け道は残しつつ、ピル2連にせず Apple風ミニマルを維持。既存 `viewWork` 文言を流用。
- **連絡先は重複させない。** 右カラムの「すべての連絡先」(`#contact`) が既にあるため。

## 3視点の合意・分岐

- **全員一致**: プライマリは `#about` へ向けるべき（数字直行が不満の原因）。ラベルも遷移先に合わせて変更すべき。
- **分岐（ボタン数）**: 1個維持 / about+contact の2個 / 塗り+テキストリンクの2個 → **塗りピル(#about) + テキストリンク(#highlights)** を採用。ミニマルを保ちつつ抜け道も残り、contact重複も避けられる中庸。

## i18n

`hero.learnMore` を3言語に追加（`viewWork` はセカンダリに流用）。

- ja: もっと知る
- en: Learn more
- zh: 了解更多

## 影響範囲・検証

- 新規CSSなし（`.btn-pill` / `.link-accent` を流用）。ヒーローは静的のままで **LCPに影響なし**。
- `npm run typecheck && npm run lint && npm run test` … すべてパス（48 tests）。
- `tests/messages.test.ts`（3言語キー構造一致）パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra4H2CMqqDY9TLT1fzS1MZ
