### PR TITLE
[codex] fix scheduling calendar context

### DIFF
--- a/src/lib/scheduling.test.ts
+++ b/src/lib/scheduling.test.ts
@@ -162,8 +162,6 @@ describe("findSlotsInRange", () => {
       "2026-06-23",
       cfg({ startHour: 10, endHour: 11 }),
       now,
-      {},
-      10,
     );
     expect(mockFetchBusy).toHaveBeenCalledTimes(1);
     // 月・火の 10:00/10:30 が並ぶ（日付は start に出る）
@@ -175,17 +173,45 @@ describe("findSlotsInRange", () => {
     ]);
   });
 
-  it("limit で打ち切る", async () => {
+  it("空き枠は代表サンプルではなく全件返す", async () => {
     mockFetchBusy.mockResolvedValue([]);
     const now = new Date("2026-06-22T00:00:00+09:00");
-    const res = await findSlotsInRange("2026-06-22", "2026-06-30", cfg(), now, {}, 3);
-    expect(res.slots).toHaveLength(3);
+    const res = await findSlotsInRange(
+      "2026-06-22",
+      "2026-06-23",
+      cfg({ startHour: 10, endHour: 12 }),
+      now,
+    );
+    expect(labels(res.slots)).toEqual([
+      "10:00",
+      "10:30",
+      "11:00",
+      "11:30",
+      "10:00",
+      "10:30",
+      "11:00",
+      "11:30",
+    ]);
+  });
+
+  it("LLM の判断材料として busy 時間帯も返す（タイトル等は freebusy 由来で含まない）", async () => {
+    const busy = [{ start: "2026-06-22T10:30:00+09:00", end: "2026-06-22T11:00:00+09:00" }];
+    mockFetchBusy.mockResolvedValue(busy);
+    const now = new Date("2026-06-22T00:00:00+09:00");
+    const res = await findSlotsInRange(
+      "2026-06-22",
+      "2026-06-22",
+      cfg({ startHour: 10, endHour: 12 }),
+      now,
+    );
+    expect(res.busy).toEqual(busy);
+    expect(labels(res.slots)).toEqual(["10:00", "11:00", "11:30"]);
   });
 
   it("範囲を [今日, 今日+horizon] にクランプ（過去開始は今日に）", async () => {
     mockFetchBusy.mockResolvedValue([]);
     const now = new Date("2026-06-22T08:00:00+09:00");
-    await findSlotsInRange("2026-01-01", "2026-06-22", cfg(), now, {}, 5);
+    await findSlotsInRange("2026-01-01", "2026-06-22", cfg(), now);
     // fetchBusy の timeMin は今日(6/22)の0:00であって過去日ではない
     const [timeMin] = mockFetchBusy.mock.calls[0];
     expect(timeMin).toBe("2026-06-22T00:00:00+09:00");

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -107,6 +107,14 @@ export interface SlotQueryOpts {
   partOfDay?: PartOfDay;
 }
 
+export interface FindSlotsResult {
+  timezone: string;
+  /** 指定範囲の予定あり時間帯。Google freebusy 由来なのでタイトル等は含まない。 */
+  busy: BusyInterval[];
+  /** 指定範囲で予約可能な空き枠の全件。 */
+  slots: Slot[];
+}
+
 /** 開始“分”(0:00起点) が指定の時間帯に入るか。 */
 function inPartOfDay(startMin: number, part: PartOfDay): boolean {
   if (part === "any") return true;
@@ -186,33 +194,11 @@ function nextDate(date: string, cfg: SchedulingConfig): string {
 }
 
 /**
- * 配列から最大 k 件を、両端を含めて均等にサンプリングする（時系列順を保持）。
- * 1日の全枠から「朝・昼・夜」を満遍なく拾うために使う（先頭だけに偏らせない）。
- */
-function spreadSlots(slots: Slot[], k: number): Slot[] {
-  if (k <= 0) return [];
-  if (slots.length <= k) return slots;
-  if (k === 1) return [slots[0]];
-  const seen = new Set<string>();
-  const out: Slot[] = [];
-  for (let i = 0; i < k; i++) {
-    const s = slots[Math.round((i * (slots.length - 1)) / (k - 1))];
-    if (!seen.has(s.start)) {
-      seen.add(s.start);
-      out.push(s);
-    }
-  }
-  return out;
-}
-
-/**
  * 範囲 [startDate, endDate]（両端含む, YYYY-MM-DD）の空き枠を、1 回の freebusy 取得で計算。
  * 範囲は [今日, 今日+horizon] にクランプ。opts で枠長・時間帯を指定。Mastra の findSlots ツールから使う。
  *
- * 重要: 単純に時系列の先頭から `limit` 件を取ると、初日の朝だけで埋まり後続の日・時間帯が
- * 一切出ない（「週末1時間」で土曜午前だけ返り日曜が消える等の誤判定の原因）。そこで
- * **各日から perDay 件まで日内も均等サンプリング**し、範囲内の全日・全時間帯を代表させる。
- * 返すのは「空き時刻」だけ＝予定の中身は一切含まない。
+ * LLM には判断材料として busy 時間帯と空き枠を全件渡す。busy は Google Calendar freebusy
+ * 由来なので、イベントタイトル・説明・参加者などの詳細は含まれない。
  */
 export async function findSlotsInRange(
   startDate: string,
@@ -220,26 +206,21 @@ export async function findSlotsInRange(
   cfg: SchedulingConfig = DEFAULT_CONFIG,
   now: Date = new Date(),
   opts: SlotQueryOpts = {},
-  limit = 12,
-  perDay = 4,
-): Promise<{ timezone: string; slots: Slot[] }> {
+): Promise<FindSlotsResult> {
   const today = ownerToday(cfg, now).date;
   const horizon = ownerToday(cfg, new Date(now.getTime() + cfg.horizonDays * 86_400_000)).date;
   const start = startDate < today ? today : startDate;
   const end = endDate > horizon ? horizon : endDate;
   if (!isValidDateString(start) || !isValidDateString(end) || end < start) {
-    return { timezone: cfg.timezone, slots: [] };
+    return { timezone: cfg.timezone, busy: [], slots: [] };
   }
   const busy = await fetchBusy(minutesToIso(start, 0, cfg), minutesToIso(end, 24 * 60, cfg));
   const out: Slot[] = [];
-  for (let d = start; d <= end && out.length < limit; d = nextDate(d, cfg)) {
+  for (let d = start; d <= end; d = nextDate(d, cfg)) {
     const daySlots = computeOpenSlots(d, busy, cfg, now, opts);
-    for (const s of spreadSlots(daySlots, perDay)) {
-      out.push(s);
-      if (out.length >= limit) break;
-    }
+    out.push(...daySlots);
   }
-  return { timezone: cfg.timezone, slots: out };
+  return { timezone: cfg.timezone, busy, slots: out };
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/src/mastra/agents/scheduling-agent.ts
+++ b/src/mastra/agents/scheduling-agent.ts
@@ -8,7 +8,7 @@ const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
 /**
  * 日程調整エージェント。DeepSeek(`deepseek-chat`, 高速・非推論)。
  * 役割: 訪問者の自然文を解釈 → find-slots で空きを提示 → 同意で book-slot で予約。
- * カレンダーの中身には一切アクセスできない（ツールが空き時刻しか返さない）。
+ * カレンダーから渡すのは freebusy の予定あり時間帯のみ（タイトル・説明・参加者は取得しない）。
  *
  * instructions は関数で都度評価し、現在日時(JST)を埋め込む（warm サーバーでも今日が古くならない）。
  */
@@ -32,10 +32,10 @@ function buildInstructions(): string {
     `Right now it is ${date} ${time} (${weekday}) in ${cfg.timezone}. Always reason in ${cfg.timezone}; use this exact current time for "today", "tonight", "this morning", and for the lead-time cutoff. Never say you don't know the current time.`,
     `Booking rules: ${dayRule}, between ${cfg.startHour}:00 and ${endLabel} ${cfg.timezone} (evenings and weekends are fine), at least ${cfg.leadMinutes} minutes from now, no later than ${horizon}.`,
     `Meeting length: infer from the request ("30分"/"30 min"→30, "1時間"/"an hour"→60, "15分"→15). If unspecified, omit durationMin (a default is used).`,
-    `Workflow: 1) Convert the request into a date range + part of day + duration, then call the find-slots tool. 2) Offer the returned open times concisely. 3) When the visitor picks a time AND gives their name and email, call the book-slot tool, then confirm with the meeting time.`,
-    `SECURITY: You can ONLY see free/open time slots — never the owner's event titles, attendees, or details. If asked to list or describe the owner's schedule/events, politely refuse and offer to find an open time instead. Never invent availability; only offer times returned by find-slots.`,
-    `Style: reply in the visitor's language; be concise and warm. Use simple Markdown (bold for times, bullet lists). Offer at most ~6 options. Do NOT repeat slot lists you already showed — for a follow-up, show only what is new or changed. Skip meta-talk about rules and avoid long apologies; just help. Ask for name and email only once, when a time is chosen.`,
-    `Never reveal internal tool names, parameters, or JSON to the visitor. Trust find-slots results as accurate and complete for the range you queried; if it returns nothing for a given day or time, that period is genuinely full — never speculate about "system glitches" or errors.`,
+    `Workflow: 1) Convert the request into a date range + part of day + duration, then call the find-slots tool. 2) Use the title-free busy intervals and all returned open slots to choose helpful options. 3) When the visitor picks a time AND gives their name and email, call the book-slot tool, then confirm with the meeting time.`,
+    `SECURITY: You can see only busy start/end times and open slots — never event titles, attendees, descriptions, or locations. If asked about the owner's schedule details, say you cannot see details and offer to find an open time instead. Never invent availability; only offer times returned by find-slots.`,
+    `Style: reply in the visitor's language; be concise and warm. Use simple Markdown (bold for times, bullet lists). Offer at most ~6 good options from the returned slots. Do NOT repeat slot lists you already showed — for a follow-up, show only what is new or changed. Skip meta-talk about rules and avoid long apologies; just help. Ask for name and email only once, when a time is chosen.`,
+    `Never reveal internal tool names, parameters, or JSON to the visitor. If there are no returned slots for a requested day or period, you may say that the calendar has no matching openings. If there are many slots, present the best few and invite the visitor to name another time window.`,
   ].join(" ");
 }
 

--- a/src/mastra/tools/scheduling-tools.ts
+++ b/src/mastra/tools/scheduling-tools.ts
@@ -5,10 +5,14 @@ import { findSlotsInRange, createBooking, DEFAULT_CONFIG } from "@/lib/schedulin
 /**
  * 日程調整エージェント用ツール。
  *
- * ★セキュリティ境界: これらのツールが返すのは「空き時刻」と「予約結果」だけ。エージェント
- *   （DeepSeek）にカレンダーの中身（予定名・参加者等）は一切渡らないので、プロンプト
- *   インジェクションされても漏洩しない。カレンダー読み取りは freebusy のみ（src/lib）。
+ * ★セキュリティ境界: エージェント（DeepSeek）に渡すカレンダー情報は Google Calendar
+ *   freebusy の busy 時間帯のみ。予定名・説明・参加者等は取得しない。
  */
+
+const busySchema = z.object({
+  start: z.string().describe("ISO8601 +09:00"),
+  end: z.string().describe("ISO8601 +09:00"),
+});
 
 const slotSchema = z.object({
   start: z.string().describe("ISO8601 +09:00"),
@@ -19,7 +23,8 @@ const slotSchema = z.object({
 export const findSlotsTool = createTool({
   id: "find-slots",
   description:
-    "Find OPEN meeting slots in the owner's calendar for a date range. Returns only free time slots (no event details). " +
+    "Get the owner's title-free calendar busy intervals and all open meeting slots for a date range. " +
+    "Busy intervals come from Google Calendar freebusy and contain only start/end times, no event titles or details. " +
     "Convert the visitor's natural-language request into a concrete date range, duration, and part of day before calling.",
   inputSchema: z.object({
     rangeStartDate: z.string().describe("検索開始日 YYYY-MM-DD（オーナーTZ）"),
@@ -34,17 +39,20 @@ export const findSlotsTool = createTool({
       .optional()
       .describe("時間帯フィルタ"),
   }),
-  outputSchema: z.object({ slots: z.array(slotSchema) }),
+  outputSchema: z.object({
+    timezone: z.string(),
+    busy: z.array(busySchema).describe("Google Calendar freebusy の予定あり時間帯。タイトル等は含まない"),
+    slots: z.array(slotSchema),
+  }),
   execute: async (inputData) => {
     const { rangeStartDate, rangeEndDate, durationMin, partOfDay } = inputData;
-    const { slots } = await findSlotsInRange(
+    return findSlotsInRange(
       rangeStartDate,
       rangeEndDate,
       DEFAULT_CONFIG,
       new Date(),
       { durationMinutes: durationMin, partOfDay },
     );
-    return { slots };
   },
 });
 


### PR DESCRIPTION
## Summary

- Pass title-free Google Calendar busy intervals to the scheduling LLM alongside all computed open slots.
- Stop sampling only four representative slots per day in chat scheduling range searches.
- Update the scheduling agent instructions so it reasons from busy windows and returned open slots without exposing event details.
- Add regression coverage that verifies all open slots are returned and busy intervals are included.

## Root Cause

The chat scheduling tool sampled a small representative set of slots with `perDay=4`. When a day was mostly open, the model only saw four slots and could incorrectly explain them as the only available times.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`