### PR TITLE
[codex] Fix initial hash section scrolling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Typecheck, lint, test, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
       - name: Typecheck
         run: npm run typecheck
 
@@ -46,3 +49,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: E2E
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
@@ -1875,6 +1876,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -9534,6 +9551,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "next lint --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "prepare": "simple-git-hooks"
   },
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm start",
+    url: "http://127.0.0.1:3000",
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 5"],
+      },
+    },
+  ],
+});

--- a/src/hooks/useScrollNavigation.test.tsx
+++ b/src/hooks/useScrollNavigation.test.tsx
@@ -4,6 +4,8 @@ import { useScrollNavigation } from "@/hooks/useScrollNavigation";
 import { SECTION_IDS } from "@/lib/sections";
 import { IntersectionObserverStub } from "../../vitest.setup";
 
+const SECTION_HASH_IDS = SECTION_IDS.filter((id) => id !== "hero");
+
 // usePathname / useParams を可変モックにする。Next.js App Router は
 // history.replaceState をパッチしていて scroll-spy の URL 書き換えでも
 // usePathname() が更新されるため、その挙動を navState + rerender で再現する。
@@ -30,6 +32,10 @@ function fireIntersection(sectionId: string) {
   act(() => {
     observer!.callback([entry], observer as unknown as IntersectionObserver);
   });
+}
+
+function competingSectionFor(sectionId: string) {
+  return SECTION_IDS.find((id) => id !== sectionId) ?? "hero";
 }
 
 describe("useScrollNavigation", () => {
@@ -70,9 +76,53 @@ describe("useScrollNavigation", () => {
     );
   });
 
-  it("初回マウント時、URL ハッシュのセクションへ補正スクロールする", () => {
+  it.each(SECTION_HASH_IDS)(
+    "初回マウント時、URL ハッシュ #%s のセクションへ補正スクロールする",
+    (sectionId) => {
+      navState.pathname = "/ja";
+      window.history.replaceState({}, "", `/ja#${sectionId}`);
+
+      const { result } = renderHook(() => useScrollNavigation());
+
+      expect(result.current.currentSection).toBe(sectionId);
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+        document.getElementById(sectionId)
+      );
+      expect(window.location.pathname).toBe(`/ja/${sectionId}`);
+      expect(window.location.hash).toBe("");
+    }
+  );
+
+  it.each(SECTION_HASH_IDS)(
+    "初回ハッシュ #%s の補正中は scroll-spy が別セクションを現在地にしない",
+    (sectionId) => {
+      navState.pathname = "/ja";
+      window.history.replaceState({}, "", `/ja#${sectionId}`);
+
+      const { result } = renderHook(() => useScrollNavigation());
+      const competingSection = competingSectionFor(sectionId);
+
+      fireIntersection(competingSection);
+      expect(result.current.currentSection).toBe(sectionId);
+      expect(window.location.pathname).toBe("/ja");
+      expect(window.location.hash).toBe(`#${sectionId}`);
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      expect(result.current.currentSection).toBe(sectionId);
+      expect(window.location.pathname).toBe(`/ja/${sectionId}`);
+    }
+  );
+
+  it("初回 URL で path と hash が異なる場合は hash を優先する", () => {
     navState.pathname = "/ja";
-    window.history.replaceState({}, "", "/ja#scheduling");
+    window.history.replaceState({}, "", "/ja/skills#scheduling");
 
     const { result } = renderHook(() => useScrollNavigation());
 
@@ -87,24 +137,6 @@ describe("useScrollNavigation", () => {
     );
     expect(window.location.pathname).toBe("/ja/scheduling");
     expect(window.location.hash).toBe("");
-  });
-
-  it("初回ハッシュ補正中は scroll-spy が手前のセクションを現在地にしない", () => {
-    navState.pathname = "/ja";
-    window.history.replaceState({}, "", "/ja#scheduling");
-
-    const { result } = renderHook(() => useScrollNavigation());
-
-    fireIntersection("skills");
-    expect(result.current.currentSection).toBe("scheduling");
-    expect(window.location.pathname).toBe("/ja");
-    expect(window.location.hash).toBe("#scheduling");
-
-    act(() => {
-      vi.advanceTimersByTime(150);
-    });
-    expect(result.current.currentSection).toBe("scheduling");
-    expect(window.location.pathname).toBe("/ja/scheduling");
   });
 
   it("scroll-spy が URL を /{locale}/{section} に書き換える", () => {
@@ -241,29 +273,32 @@ describe("useScrollNavigation", () => {
     );
   });
 
-  it("セクションへの hashchange は通常ナビと同じく URL と現在地を確定する", async () => {
-    const { result } = renderHook(() => useScrollNavigation());
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-    scrollIntoViewSpy.mockClear();
+  it.each(SECTION_HASH_IDS)(
+    "セクション #%s への hashchange は通常ナビと同じく URL と現在地を確定する",
+    async (sectionId) => {
+      const { result } = renderHook(() => useScrollNavigation());
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      scrollIntoViewSpy.mockClear();
 
-    await act(async () => {
-      window.history.replaceState({}, "", "/ja#scheduling");
-      window.dispatchEvent(new HashChangeEvent("hashchange"));
-    });
+      await act(async () => {
+        window.history.replaceState({}, "", `/ja#${sectionId}`);
+        window.dispatchEvent(new HashChangeEvent("hashchange"));
+      });
 
-    expect(window.location.pathname).toBe("/ja/scheduling");
-    expect(window.location.hash).toBe("");
-    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
-      document.getElementById("scheduling")
-    );
-    expect(result.current.currentSection).toBe("scheduling");
+      expect(window.location.pathname).toBe(`/ja/${sectionId}`);
+      expect(window.location.hash).toBe("");
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+        document.getElementById(sectionId)
+      );
+      expect(result.current.currentSection).toBe(sectionId);
 
-    fireIntersection("skills");
-    expect(result.current.currentSection).toBe("scheduling");
-    expect(window.location.pathname).toBe("/ja/scheduling");
-  });
+      fireIntersection(competingSectionFor(sectionId));
+      expect(result.current.currentSection).toBe(sectionId);
+      expect(window.location.pathname).toBe(`/ja/${sectionId}`);
+    }
+  );
 
   // ハッシュ駆動ダイアログ（#contact = ContactModal）は対象要素が無い。
   // ハンドラが落ちたりスクロールしたりしないこと。

--- a/src/hooks/useScrollNavigation.test.tsx
+++ b/src/hooks/useScrollNavigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, cleanup } from "@testing-library/react";
 import { useScrollNavigation } from "@/hooks/useScrollNavigation";
 import { SECTION_IDS } from "@/lib/sections";
 import { IntersectionObserverStub } from "../../vitest.setup";
@@ -49,6 +49,7 @@ describe("useScrollNavigation", () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
+    cleanup();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -67,6 +68,43 @@ describe("useScrollNavigation", () => {
     expect(scrollIntoViewSpy.mock.instances[0]).toBe(
       document.getElementById("skills")
     );
+  });
+
+  it("初回マウント時、URL ハッシュのセクションへ補正スクロールする", () => {
+    navState.pathname = "/ja";
+    window.history.replaceState({}, "", "/ja#scheduling");
+
+    const { result } = renderHook(() => useScrollNavigation());
+
+    expect(result.current.currentSection).toBe("scheduling");
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+      document.getElementById("scheduling")
+    );
+    expect(window.location.pathname).toBe("/ja/scheduling");
+    expect(window.location.hash).toBe("");
+  });
+
+  it("初回ハッシュ補正中は scroll-spy が手前のセクションを現在地にしない", () => {
+    navState.pathname = "/ja";
+    window.history.replaceState({}, "", "/ja#scheduling");
+
+    const { result } = renderHook(() => useScrollNavigation());
+
+    fireIntersection("skills");
+    expect(result.current.currentSection).toBe("scheduling");
+    expect(window.location.pathname).toBe("/ja");
+    expect(window.location.hash).toBe("#scheduling");
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.currentSection).toBe("scheduling");
+    expect(window.location.pathname).toBe("/ja/scheduling");
   });
 
   it("scroll-spy が URL を /{locale}/{section} に書き換える", () => {
@@ -183,8 +221,9 @@ describe("useScrollNavigation", () => {
   });
 
   // ページ内アンカーのクリックは hashchange を発火する。
-  // settle スクロールが適用されること。
-  it("hashchange でハッシュ先の要素へスクロールする", () => {
+  // SECTION_IDS 以外の実在アンカーにも settle スクロールが適用されること。
+  it("hashchange で非セクションのハッシュ先要素へスクロールする", () => {
+    document.body.insertAdjacentHTML("beforeend", '<section id="highlights"></section>');
     renderHook(() => useScrollNavigation());
     act(() => {
       vi.advanceTimersByTime(200);
@@ -192,14 +231,38 @@ describe("useScrollNavigation", () => {
     scrollIntoViewSpy.mockClear();
 
     act(() => {
-      window.history.replaceState({}, "", "/ja#blog");
+      window.history.replaceState({}, "", "/ja#highlights");
       window.dispatchEvent(new HashChangeEvent("hashchange"));
     });
 
     expect(scrollIntoViewSpy).toHaveBeenCalled();
     expect(scrollIntoViewSpy.mock.instances[0]).toBe(
-      document.getElementById("blog")
+      document.getElementById("highlights")
     );
+  });
+
+  it("セクションへの hashchange は通常ナビと同じく URL と現在地を確定する", async () => {
+    const { result } = renderHook(() => useScrollNavigation());
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    scrollIntoViewSpy.mockClear();
+
+    await act(async () => {
+      window.history.replaceState({}, "", "/ja#scheduling");
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+
+    expect(window.location.pathname).toBe("/ja/scheduling");
+    expect(window.location.hash).toBe("");
+    expect(scrollIntoViewSpy.mock.instances[0]).toBe(
+      document.getElementById("scheduling")
+    );
+    expect(result.current.currentSection).toBe("scheduling");
+
+    fireIntersection("skills");
+    expect(result.current.currentSection).toBe("scheduling");
+    expect(window.location.pathname).toBe("/ja/scheduling");
   });
 
   // ハッシュ駆動ダイアログ（#contact = ContactModal）は対象要素が無い。

--- a/src/hooks/useScrollNavigation.ts
+++ b/src/hooks/useScrollNavigation.ts
@@ -59,6 +59,8 @@ export function useScrollNavigation() {
 
     // Observerを作成
     const observerCallback: IntersectionObserverCallback = (entries) => {
+      if (isNavigatingRef.current) return;
+
       // 現在のビューポート内で最も上にあるセクションを検出
       let topSection: TopSection | null = null;
 
@@ -164,6 +166,10 @@ export function useScrollNavigation() {
     const onHashChange = () => {
       const id = window.location.hash.slice(1);
       if (!id) return;
+      if (sectionIds.includes(id)) {
+        scrollToSection(id);
+        return;
+      }
       const element = document.getElementById(id);
       if (!element) return;
       cancelSettleRef.current?.();
@@ -174,7 +180,7 @@ export function useScrollNavigation() {
       window.removeEventListener("hashchange", onHashChange);
       cancelSettleRef.current?.();
     };
-  }, []);
+  }, [scrollToSection, sectionIds]);
 
   // 直接URLアクセス時の処理（初回マウント時のみ）。
   //
@@ -189,18 +195,27 @@ export function useScrollNavigation() {
     if (hasHandledInitialPathRef.current) return;
     hasHandledInitialPathRef.current = true;
 
+    const hashSection = window.location.hash.slice(1);
     const pathParts = pathname.split("/");
-    const section = pathParts[pathParts.length - 1];
+    const pathSection = pathParts[pathParts.length - 1];
+    const section = sectionIds.includes(hashSection) ? hashSection : pathSection;
 
-    // セクションIDが存在する場合はそこにスクロール
+    // セクションIDが存在する場合はそこにスクロール。
+    // /{locale}/{section} は Next redirects で /{locale}#section になるため、
+    // 初回ロード時のハッシュもここで明示的に補正スクロールする。
     if (section && sectionIds.includes(section)) {
+      isNavigatingRef.current = true;
       currentSectionRef.current = section;
       setCurrentSection(section);
       // ページ読み込み完了後にスクロール
       setTimeout(() => {
-        scrollToSection(section);
+        if (document.getElementById(section)) {
+          scrollToSection(section);
+        } else {
+          isNavigatingRef.current = false;
+        }
       }, 100);
-    } else if (section === locale || !section) {
+    } else if (pathSection === locale || !pathSection) {
       currentSectionRef.current = "hero";
       setCurrentSection("hero");
     }

--- a/tests/e2e/section-deeplinks.spec.ts
+++ b/tests/e2e/section-deeplinks.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+const SECTION_IDS = [
+  "about",
+  "experience",
+  "projects",
+  "research",
+  "skills",
+  "scheduling",
+  "blog",
+] as const;
+
+test.describe("section deep links", () => {
+  for (const sectionId of SECTION_IDS) {
+    test(`/${sectionId} lands with #${sectionId} at the top of the viewport`, async ({
+      page,
+    }) => {
+      await page.goto(`/ja/${sectionId}`, { waitUntil: "networkidle" });
+
+      await expect
+        .poll(async () => {
+          return page.evaluate((id) => {
+            const target = document.getElementById(id);
+            const top = target?.getBoundingClientRect().top ?? Number.NaN;
+            const activeSection = document
+              .elementFromPoint(window.innerWidth / 2, 120)
+              ?.closest("section")?.id;
+
+            return {
+              activeSection,
+              hash: window.location.hash,
+              pathname: window.location.pathname,
+              top,
+              topWithinTolerance: Math.abs(top) <= 1,
+            };
+          }, sectionId);
+        })
+        .toMatchObject({
+          activeSection: sectionId,
+          hash: "",
+          pathname: `/ja/${sectionId}`,
+          topWithinTolerance: true,
+        });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Fix initial section-hash landing so `/ja/scheduling` reaches the scheduling section instead of being captured by the preceding skills section.
- Route section `hashchange` events through the same locked `scrollToSection` path used by navigation buttons.
- Add broader regression tests for every section hash, scroll-spy lockout while settling, section hash changes, and non-section hash anchors.
- Add GitHub Actions CI for typecheck, lint, unit tests, production build, and mobile Chromium E2E deep-link checks.

## Root Cause

Production redirects `/ja/scheduling` to `/ja#scheduling`. On mobile, the browser's native initial fragment scroll can run before layout settles, leaving the viewport inside `#skills`. Because `useScrollNavigation` only handled pathname sections on initial mount and only handled future `hashchange` events, the settled-scroll correction never ran for the initial hash. The scroll-spy then observed `skills` and rewrote the URL to `/ja/skills`.

## Follow-up Hardening

The new E2E suite opens the built app in a mobile Chromium viewport and checks every `/ja/{section}` deep link lands with the target section active at the top of the viewport. This cannot make arbitrary future DOM/CSS changes mathematically impossible to break, but it makes the relevant regression fail in CI before merge.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:e2e`
- GitHub Actions `CI / Typecheck, lint, test, and build`: passed
- Local production browser check: `http://localhost:3000/ja/scheduling` landed with `activeAt120: "scheduling"` and `scheduling.top: 0`.
