### PR TITLE
fix(i18n): Navigation の aria-label を多言語化

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,11 @@
     "more": "More",
     "scrollToNext": "Next Section:",
     "scrollToPrevious": "Previous Section:",
-    "navigating": "Navigating..."
+    "navigating": "Navigating...",
+    "toggleDarkMode": "Toggle dark mode",
+    "languageLabel": "Language: {lang}",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "languages": {
     "ja": "Japanese",
@@ -830,8 +834,17 @@
     "chatSend": "Send",
     "chatThinking": "Thinking…",
     "chatPhaseCalendar": "Checking Google Calendar…",
-    "chatPhases": ["Reading your request", "Checking Google Calendar availability", "Looking for open times", "Putting the options together"],
-    "chatExamples": ["1 hour this weekend", "Weekday evening, 30 min", "Earliest opening"],
+    "chatPhases": [
+      "Reading your request",
+      "Checking Google Calendar availability",
+      "Looking for open times",
+      "Putting the options together"
+    ],
+    "chatExamples": [
+      "1 hour this weekend",
+      "Weekday evening, 30 min",
+      "Earliest opening"
+    ],
     "chatError": "Something went wrong. Please try again.",
     "chatRetry": "Retry",
     "chatReplyOk": "Here are the closest open times — pick one below.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -15,7 +15,11 @@
     "more": "その他",
     "scrollToNext": "次のセクション：",
     "scrollToPrevious": "前のセクション：",
-    "navigating": "遷移中..."
+    "navigating": "遷移中...",
+    "toggleDarkMode": "ダークモード切り替え",
+    "languageLabel": "言語: {lang}",
+    "openMenu": "メニューを開く",
+    "closeMenu": "メニューを閉じる"
   },
   "languages": {
     "ja": "日本語",
@@ -830,8 +834,17 @@
     "chatSend": "送信",
     "chatThinking": "考えています",
     "chatPhaseCalendar": "Google カレンダーを確認しています",
-    "chatPhases": ["ご要望を読み取っています", "Google カレンダーの空き状況を確認しています", "空いている時間を探しています", "候補をまとめています"],
-    "chatExamples": ["週末に1時間", "平日の夜で30分", "直近の空き"],
+    "chatPhases": [
+      "ご要望を読み取っています",
+      "Google カレンダーの空き状況を確認しています",
+      "空いている時間を探しています",
+      "候補をまとめています"
+    ],
+    "chatExamples": [
+      "週末に1時間",
+      "平日の夜で30分",
+      "直近の空き"
+    ],
     "chatError": "うまくつながりませんでした。もう一度お試しください。",
     "chatRetry": "再試行",
     "chatReplyOk": "ご希望に近い空き枠です。下のボタンから選んでください。",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -15,7 +15,11 @@
     "more": "更多",
     "scrollToNext": "下一部分:",
     "scrollToPrevious": "上一部分:",
-    "navigating": "正在切换..."
+    "navigating": "正在切换...",
+    "toggleDarkMode": "切换深色模式",
+    "languageLabel": "语言: {lang}",
+    "openMenu": "打开菜单",
+    "closeMenu": "关闭菜单"
   },
   "languages": {
     "ja": "日本語",
@@ -830,8 +834,17 @@
     "chatSend": "发送",
     "chatThinking": "正在思考…",
     "chatPhaseCalendar": "正在查看 Google 日历…",
-    "chatPhases": ["正在理解你的请求", "正在查看 Google 日历的空闲情况", "正在寻找空闲时段", "正在整理候选时间"],
-    "chatExamples": ["周末1小时", "工作日晚上30分钟", "最近的空闲"],
+    "chatPhases": [
+      "正在理解你的请求",
+      "正在查看 Google 日历的空闲情况",
+      "正在寻找空闲时段",
+      "正在整理候选时间"
+    ],
+    "chatExamples": [
+      "周末1小时",
+      "工作日晚上30分钟",
+      "最近的空闲"
+    ],
     "chatError": "连接出现问题，请重试。",
     "chatRetry": "重试",
     "chatReplyOk": "以下是最接近的空闲时段，请在下方选择。",

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,6 +8,9 @@ import { LuMenu as Menu, LuX as X, LuMoon as Moon, LuSun as Sun } from "react-ic
 import { useScrollNavigation } from "@/hooks/useScrollNavigation";
 import { useTheme } from "@/contexts/ThemeContext";
 
+const LANGUAGE_FALLBACK: Record<string, string> = { ja: "日本語", en: "English", zh: "中文" };
+const LOCALE_FLAGS: Record<string, string> = { ja: "🇯🇵", en: "🇬🇧", zh: "🇨🇳" };
+
 const Navigation = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [showLangMenu, setShowLangMenu] = useState(false);
@@ -91,15 +94,13 @@ const Navigation = () => {
       } catch (e) {
         console.warn(`Translation error for ${code}:`, e);
       }
-      const fallback = { ja: "日本語", en: "English", zh: "中文" };
-      return fallback[code as keyof typeof fallback] || code;
+      return LANGUAGE_FALLBACK[code] || code;
     },
     [langT],
   );
 
   const getFlag = useCallback((code: string): string => {
-    const flags = { ja: "🇯🇵", en: "🇬🇧", zh: "🇨🇳" };
-    return flags[code as keyof typeof flags] || "🌍";
+    return LOCALE_FLAGS[code] || "🌍";
   }, []);
 
   const languages = [

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -240,7 +240,7 @@ const Navigation = () => {
                 type="button"
                 onClick={toggleTheme}
                 className="inline-flex items-center justify-center min-h-11 min-w-11 text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] transition-colors"
-                aria-label="Toggle dark mode"
+                aria-label={t("toggleDarkMode")}
                 aria-pressed={mounted ? theme === "dark" : undefined}
               >
                 {mounted ? (
@@ -279,7 +279,7 @@ const Navigation = () => {
                   className="inline-flex items-center gap-1.5 min-h-11 px-2.5 text-sm font-medium text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] transition-colors"
                   aria-haspopup="menu"
                   aria-expanded={showLangMenu}
-                  aria-label={`Language: ${getLanguageName(locale)}`}
+                  aria-label={t("languageLabel", { lang: getLanguageName(locale) })}
                 >
                   <span className="text-base" aria-hidden>{languages.find((l) => l.code === locale)?.flag}</span>
                   <span className="hidden sm:inline">
@@ -324,7 +324,7 @@ const Navigation = () => {
                 type="button"
                 onClick={() => setShowMoreMenu(!showMoreMenu)}
                 className="lg:hidden inline-flex items-center justify-center min-h-11 min-w-11 text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)] transition-colors"
-                aria-label="Open menu"
+                aria-label={t("openMenu")}
                 aria-haspopup="dialog"
                 aria-expanded={showMoreMenu}
                 aria-controls="mobile-menu"
@@ -355,7 +355,7 @@ const Navigation = () => {
                 type="button"
                 onClick={() => setShowMoreMenu(false)}
                 className="inline-flex items-center justify-center min-h-11 min-w-11 text-[color:var(--color-ink-soft)] hover:text-[color:var(--color-ink)]"
-                aria-label="Close menu"
+                aria-label={t("closeMenu")}
               >
                 <X size={20} />
               </button>


### PR DESCRIPTION
## Summary

`Navigation.tsx` の4つの aria-label が英語ハードコードだったため、`/ja` や `/zh` ロケールでもスクリーンリーダーが英語で読み上げてしまう問題を修正。

`messages/{ja,en,zh}.json` の `nav` に翻訳キーを追加し、既存の `useTranslations("nav")` 経由で参照するように変更。

| キー | ja | en | zh |
|---|---|---|---|
| `toggleDarkMode` | ダークモード切り替え | Toggle dark mode | 切换深色模式 |
| `languageLabel` | 言語: {lang} | Language: {lang} | 语言: {lang} |
| `openMenu` | メニューを開く | Open menu | 打开菜单 |
| `closeMenu` | メニューを閉じる | Close menu | 关闭菜单 |

```diff
- aria-label="Toggle dark mode"
+ aria-label={t("toggleDarkMode")}
- aria-label={`Language: ${getLanguageName(locale)}`}
+ aria-label={t("languageLabel", { lang: getLanguageName(locale) })}
```

新しい hook や依存の追加なし。

Link to Devin session: https://app.devin.ai/sessions/68fde7f5c50c43d2bf9ad35bbd703d21
Requested by: @ryoshin0830