### PR TITLE
fix(scheduling): handleChatStream パラメータホワイトリスト化

### DIFF
--- a/src/app/api/schedule/chat/route.ts
+++ b/src/app/api/schedule/chat/route.ts
@@ -24,7 +24,12 @@ export async function POST(req: Request) {
 
   let params;
   try {
-    params = await req.json(); // useChat の body（{ messages, trigger, ... }）。型は any。
+    const body = await req.json();
+    const messages = body?.messages;
+    if (!Array.isArray(messages) || messages.length > 50) {
+      return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+    }
+    params = { messages, trigger: body?.trigger };
   } catch {
     return NextResponse.json({ error: "invalid_body" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary

- `req.json()` のフィールドをフィルタせず `handleChatStream` に渡していた脆弱性を修正
- 訪問者が `instructions` フィールドを POST してシステムプロンプトを上書きする攻撃を遮断
- メッセージ配列の件数上限（50件）を追加し、トークン消費攻撃も抑止

---
Cross-check report finding: Critical #1 + Low #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)