### PR TITLE
fix(scheduling): data-text サジェストチップの条件修正

### DIFF
--- a/src/components/SchedulingChat.tsx
+++ b/src/components/SchedulingChat.tsx
@@ -281,7 +281,7 @@ export default function SchedulingChat() {
                             const dataText = (props as any)["data-text"] as string | undefined;
                             // href ("action:suggest") と data-text の両方でクイック返信を判定する。
                             // urlTransform / sanitize の挙動変化に対する多重防御。
-                            if (href === "action:suggest" || dataText != null) {
+                            if (href === "action:suggest") {
                               const textToSubmit = dataText || extractText(children);
                               return (
                                 <button


### PR DESCRIPTION
## Summary

- `href === "action:suggest" || dataText != null` の OR 条件を `href === "action:suggest"` のみに変更
- プロンプトインジェクション経由で表示テキストと異なる data-text を注入するソーシャルエンジニアリングを防止

---
Cross-check report finding: Medium #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)