### PR TITLE
fix(scheduling): 時刻区切り正規表現のダッシュ文字追加

### DIFF
--- a/src/components/SchedulingChat.tsx
+++ b/src/components/SchedulingChat.tsx
@@ -86,7 +86,7 @@ function rehypeWrapColumns() {
     const hasUl = tree.children.some((n: any) => n.type === 'element' && n.tagName === 'ul');
     if (!hasUl) return;
 
-    const timeSlotRegex = /(?:\d{4}[年/])?\s*\d{1,2}[/月]\d{1,2}日?\s*[(（].+?[)）]\s*\d{1,2}:\d{2}\s*[-~〜～ー]\s*\d{1,2}:\d{2}/;
+    const timeSlotRegex = /(?:\d{4}[年/])?\s*\d{1,2}[/月]\d{1,2}日?\s*[(（].+?[)）]\s*\d{1,2}:\d{2}\s*[-~〜～ー—–]\s*\d{1,2}:\d{2}/;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tree.children.forEach((node: any) => {
@@ -309,7 +309,7 @@ export default function SchedulingChat() {
                             
                             childrenArray.forEach(child => {
                               const rawText = extractText(child).trim();
-                              const timeSlotRegex = /^(?:\d{4}[年/])?\s*(\d{1,2}[/月]\d{1,2})日?\s*[(（](.+?)[)）]\s*(\d{1,2}:\d{2})\s*[-~〜～ー]\s*(\d{1,2}:\d{2})/;
+                              const timeSlotRegex = /^(?:\d{4}[年/])?\s*(\d{1,2}[/月]\d{1,2})日?\s*[(（](.+?)[)）]\s*(\d{1,2}:\d{2})\s*[-~〜～ー—–]\s*(\d{1,2}:\d{2})/;
                               const match = rawText.match(timeSlotRegex);
                               if (match) {
                                 const dateMatch = match[1].replace('月', '/');


### PR DESCRIPTION
## Summary

- 時刻スロット正規表現の区切り文字クラスに em-dash (—) と en-dash (–) を追加
- DeepSeek の出力バリエーションに対するロバスト性を向上

---
Cross-check report finding: Info #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)