### PR TITLE
fix(scheduling): rehype-sanitize の className ワイルドカード除去

### DIFF
--- a/src/components/SchedulingChat.tsx
+++ b/src/components/SchedulingChat.tsx
@@ -47,7 +47,7 @@ export const schedulingSanitizeSchema = {
   tagNames: [...new Set([...(defaultSchema.tagNames ?? []), "div", "span"])],
   attributes: {
     ...defaultSchema.attributes,
-    "*": [...stripClassName(defaultSchema.attributes?.["*"]), "className"],
+    "*": [...stripClassName(defaultSchema.attributes?.["*"])],
     a: [...stripClassName(defaultSchema.attributes?.a), "className", "dataText", "href"],
     div: [...stripClassName(defaultSchema.attributes?.div), "className"],
     span: [...stripClassName(defaultSchema.attributes?.span), "className"],


### PR DESCRIPTION
## Summary

- `schedulingSanitizeSchema` の `"*"` ワイルドカードから `className` を除去
- `a`, `div`, `span` 等の必要な要素にのみ `className` を明示的に許可（既存の個別定義で対応済み）
- AI 応答経由でのレイアウト破壊クラス注入を防止

---
Cross-check report finding: Low #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)