### PR TITLE
fix(scheduling): rehypeWrapColumns の hast テキスト抽出修正

### DIFF
--- a/src/components/SchedulingChat.tsx
+++ b/src/components/SchedulingChat.tsx
@@ -74,6 +74,13 @@ function extractText(child: any): string {
   return "";
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hastToText(node: any): string {
+  if (node.type === 'text') return node.value || '';
+  if (Array.isArray(node.children)) return node.children.map(hastToText).join('');
+  return '';
+}
+
 function rehypeWrapColumns() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (tree: any) => {
@@ -95,7 +102,7 @@ function rehypeWrapColumns() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const hasSlot = node.children?.some((li: any) => {
           if (li.type !== 'element' || li.tagName !== 'li') return false;
-          const text = extractText(li);
+          const text = hastToText(li);
           return timeSlotRegex.test(text);
         });
 


### PR DESCRIPTION
## Summary

- rehype プラグイン `rehypeWrapColumns` で hast ノードに対して正しくテキスト抽出する `hastToText` を追加
- `extractText` は React children 用のまま維持（MarkdownUl コンポーネントで使用）

---
Cross-check report finding: Info #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)