### PR TITLE
fix(scheduling): 予約者名の Unicode 制御文字除去

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -470,6 +470,10 @@ export function isOfferableSlot(
   );
 }
 
+function stripBidiAndControlChars(s: string): string {
+  return s.replace(/[​-‏‪-‮⁦-⁩﻿­]/g, '');
+}
+
 /**
  * 予約を確定する。確定前にその枠がまだ空いているか再検証し（二重予約防止）、
  * 問題なければ Hermes に Google Calendar イベント作成を依頼する。
@@ -519,8 +523,8 @@ export async function createBooking(
   if (conflict) return { ok: false, error: "slot_taken" };
 
   // ── イベント作成（オーナー本人として実行＝招待メール＋Meet が効く）──────
-  const safeName = req.name.trim().slice(0, 80);
-  const safeNote = (req.note ?? "").trim().slice(0, 500);
+  const safeName = stripBidiAndControlChars(req.name.trim()).slice(0, 80);
+  const safeNote = stripBidiAndControlChars((req.note ?? "").trim()).slice(0, 500);
   const description = safeNote
     ? `${safeNote}\n---\nCreated via ryosh.in scheduling`
     : "Created via ryosh.in scheduling";


### PR DESCRIPTION
## Summary

- `createBooking` で予約者名・メモから Unicode 方向制御文字（RLO, LRI 等）を除去
- Google Calendar UI でのビジュアルスプーフィングを防止

---
Cross-check report finding: Low #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)