### PR TITLE
chore(scheduling): Hermes 参照の更新

### DIFF
--- a/src/app/api/schedule/book/route.ts
+++ b/src/app/api/schedule/book/route.ts
@@ -24,7 +24,7 @@ const bookingSchema = z.object({
 /**
  * POST /api/schedule/book
  * body: BookingRequest（start/end/name/note + ハニーポット company）
- * 確定直前に空き状況を再検証してから Hermes に Google Calendar イベントを作らせる。
+ * 確定直前に空き状況を再検証してから Google Calendar にイベントを作成する。
  */
 export async function POST(req: Request) {
   if (!isGoogleConfigured()) {

--- a/src/components/SchedulingSection.tsx
+++ b/src/components/SchedulingSection.tsx
@@ -6,7 +6,7 @@ import SchedulingChat from "./SchedulingChat";
  *
  * Server Component。見出しはサーバーで描画し、対話的なチャット本体だけを
  * クライアント（SchedulingChat）に委ねる。訪問者は自然言語で要望を書き、
- * /api/schedule/* 経由でサーバー側 → Hermes(自宅Mac) → Google Calendar と流れる。
+ * /api/schedule/* 経由でサーバー側 → Google Calendar API (OAuth2 直接) と流れる。
  */
 export default async function SchedulingSection() {
   const t = await getTranslations("scheduling");

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -1,12 +1,12 @@
 /**
  * AI 日程調整機能の型契約。
  *
- * データフロー: ブラウザ ──/api/schedule/*──▶ Next.js(サーバー) ──▶ Hermes(自宅Mac)
- * ──▶ Google Calendar。秘密情報（Hermes の API キー / Google 資格情報）は一切
+ * データフロー: ブラウザ ──/api/schedule/*──▶ Next.js(サーバー) ──▶ Google Calendar API
+ * (OAuth2 直接)。秘密情報（Google 資格情報）は一切
  * クライアントに出さず、ブラウザには「空き枠リスト」と「予約結果」だけ返す。
  */
 
-/** Hermes（= Google Calendar）から取得した予定済み区間。ISO8601（オフセット付き）。 */
+/** Google Calendar から取得した予定済み区間。ISO8601（オフセット付き）。 */
 export interface BusyInterval {
   start: string;
   end: string;


### PR DESCRIPTION
## Summary

- `types/scheduling.ts` のデータフロー docstring を更新（Hermes → Google Calendar API direct）
- `book/route.ts` のコメントを更新
- `SchedulingSection.tsx` のコメントを更新

---
Cross-check report finding: Info #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)