### PR TITLE
予約機能をDeepSeek V4 Flashへ移行

### DIFF
--- a/docs/superpowers/plans/2026-08-08-deepseek-v4-flash.md
+++ b/docs/superpowers/plans/2026-08-08-deepseek-v4-flash.md
@@ -1,0 +1,184 @@
+# DeepSeek V4 Flash Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Use `deepseek-v4-flash` consistently for both LLM call sites in the portfolio scheduling feature.
+
+**Architecture:** Add one scheduling-specific model factory that owns the DeepSeek model ID and provider construction. The scheduling agent and travel-padding classifier consume that factory, while their existing API-key checks, fallbacks, prompts, and response behavior remain unchanged.
+
+**Tech Stack:** TypeScript 5, Next.js 15, AI SDK 6, `@ai-sdk/deepseek` 2, Mastra, Vitest 4
+
+## Global Constraints
+
+- The scheduling model ID must be exactly `deepseek-v4-flash`.
+- Both the scheduling chat agent and travel-padding classifier must use the shared factory.
+- Preserve the `DEEPSEEK_API_KEY` environment-variable contract.
+- Preserve the heuristic fallback when the API key is absent or travel classification fails.
+- Do not change slot calculation, Google Calendar integration, prompts, or API response contracts.
+
+---
+
+### Task 1: Centralize and Migrate the Scheduling Model
+
+**Files:**
+- Create: `src/lib/scheduling-model.test.ts`
+- Create: `src/lib/scheduling-model.ts`
+- Modify: `src/lib/scheduling.ts:1-2,223-229`
+- Modify: `src/mastra/agents/scheduling-agent.ts:1-10,61`
+
+**Interfaces:**
+- Consumes: `createDeepSeek(options?: { apiKey?: string })` from `@ai-sdk/deepseek`
+- Produces: `SCHEDULING_MODEL_ID` with literal value `deepseek-v4-flash`
+- Produces: `createSchedulingModel(apiKey: string | undefined)` returning an AI SDK `LanguageModelV3`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `src/lib/scheduling-model.test.ts`:
+
+```typescript
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createDeepSeekMock, providerMock } = vi.hoisted(() => ({
+  createDeepSeekMock: vi.fn(),
+  providerMock: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/deepseek", () => ({
+  createDeepSeek: createDeepSeekMock,
+}));
+
+import {
+  createSchedulingModel,
+  SCHEDULING_MODEL_ID,
+} from "./scheduling-model";
+
+const ROOT = path.resolve(__dirname, "../..");
+const consumers = [
+  "src/lib/scheduling.ts",
+  "src/mastra/agents/scheduling-agent.ts",
+];
+
+describe("scheduling model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDeepSeekMock.mockReturnValue(providerMock);
+  });
+
+  it("creates the DeepSeek V4 Flash model with the provided API key", () => {
+    const expectedModel = { id: "test-model" };
+    providerMock.mockReturnValue(expectedModel);
+
+    const model = createSchedulingModel("test-api-key");
+
+    expect(SCHEDULING_MODEL_ID).toBe("deepseek-v4-flash");
+    expect(createDeepSeekMock).toHaveBeenCalledWith({ apiKey: "test-api-key" });
+    expect(providerMock).toHaveBeenCalledWith("deepseek-v4-flash");
+    expect(model).toBe(expectedModel);
+  });
+
+  it.each(consumers)("wires %s through the shared model factory", (file) => {
+    const source = fs.readFileSync(path.join(ROOT, file), "utf8");
+
+    expect(source).toContain("createSchedulingModel");
+    expect(source).not.toContain("deepseek-chat");
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/lib/scheduling-model.test.ts
+```
+
+Expected: FAIL because `./scheduling-model` does not exist and both consumers still contain `deepseek("deepseek-chat")`.
+
+- [ ] **Step 3: Add the shared model factory**
+
+Create `src/lib/scheduling-model.ts`:
+
+```typescript
+import { createDeepSeek } from "@ai-sdk/deepseek";
+
+export const SCHEDULING_MODEL_ID = "deepseek-v4-flash";
+
+export function createSchedulingModel(apiKey: string | undefined) {
+  const deepseek = createDeepSeek({ apiKey });
+  return deepseek(SCHEDULING_MODEL_ID);
+}
+```
+
+- [ ] **Step 4: Route the travel-padding classifier through the factory**
+
+In `src/lib/scheduling.ts`, remove the direct `createDeepSeek` import, add:
+
+```typescript
+import { createSchedulingModel } from "@/lib/scheduling-model";
+```
+
+Then replace the provider construction and model selection with:
+
+```typescript
+const { output } = await generateText({
+  model: createSchedulingModel(process.env.DEEPSEEK_API_KEY),
+```
+
+Keep the existing API-key guard and `catch` fallback unchanged.
+
+- [ ] **Step 5: Route the scheduling agent through the factory**
+
+In `src/mastra/agents/scheduling-agent.ts`, remove the direct `createDeepSeek` import, add:
+
+```typescript
+import { createSchedulingModel } from "@/lib/scheduling-model";
+```
+
+Construct the shared model once:
+
+```typescript
+const schedulingModel = createSchedulingModel(process.env.DEEPSEEK_API_KEY);
+```
+
+Pass it to the agent:
+
+```typescript
+model: schedulingModel,
+```
+
+Update the nearby model comment from `deepseek-chat` to `deepseek-v4-flash`.
+
+- [ ] **Step 6: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/lib/scheduling-model.test.ts
+```
+
+Expected: PASS with 3 tests and 0 failures.
+
+- [ ] **Step 7: Run full verification**
+
+Run:
+
+```bash
+npm run test
+npm run typecheck
+npm run lint
+npm run build
+git diff --check
+rg -n 'deepseek-chat|deepseek-v4-flash|createSchedulingModel' src/lib src/mastra
+```
+
+Expected: all commands exit 0; the only scheduling model ID is `deepseek-v4-flash`; both consumers reference `createSchedulingModel`.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add src/lib/scheduling-model.test.ts src/lib/scheduling-model.ts src/lib/scheduling.ts src/mastra/agents/scheduling-agent.ts
+git commit -m "feat(scheduling): DeepSeek V4 Flashへ移行"
+```

--- a/docs/superpowers/specs/2026-08-08-deepseek-v4-flash-design.md
+++ b/docs/superpowers/specs/2026-08-08-deepseek-v4-flash-design.md
@@ -1,0 +1,59 @@
+# 予約機能のDeepSeek V4 Flash移行 設計
+
+## 目的
+
+ポートフォリオサイトの予約機能で使用するDeepSeekモデルを、現在の
+`deepseek-chat` から `deepseek-v4-flash` へ変更する。予約会話と移動要否判定で
+同じモデル設定を共有し、将来の変更時に片方だけが古い設定に残ることを防ぐ。
+
+## 対象範囲
+
+- `src/mastra/agents/scheduling-agent.ts` の予約会話エージェント
+- `src/lib/scheduling.ts` のカレンダー予定に対する移動要否判定
+- 上記2箇所が使用する共有モデル生成ヘルパーと、その回帰テスト
+
+予約枠の計算、Google Calendar連携、会話指示、APIレスポンス、環境変数の契約は
+変更しない。
+
+## 設計
+
+`src/lib/scheduling-model.ts` を追加し、予約機能専用のモデルID定数
+`SCHEDULING_MODEL_ID` と、DeepSeekプロバイダーからモデルを生成する
+`createSchedulingModel` を公開する。モデルIDは `deepseek-v4-flash` に固定する。
+
+予約会話エージェントと移動要否判定は、個別に `createDeepSeek` とモデル文字列を
+組み立てず、`createSchedulingModel` を呼び出す。APIキーを引数として渡す既存の
+責務は維持するため、秘密情報の扱いや環境変数名は変わらない。
+
+データフローは次のとおり。
+
+1. 呼び出し元が `DEEPSEEK_API_KEY` を取得する。
+2. `createSchedulingModel` がAPIキーでDeepSeekプロバイダーを作成する。
+3. プロバイダーへ `deepseek-v4-flash` を渡し、AI SDK用のモデルを返す。
+4. Mastraエージェントまたは `generateText` が返されたモデルを使用する。
+
+## エラー処理
+
+移動要否判定は、APIキーが未設定の場合にLLMを呼ばず、既存のヒューリスティックへ
+フォールバックする。LLM呼び出しが失敗した場合も同じフォールバックを維持する。
+予約会話APIの未設定時503応答と上流エラー時502応答も変更しない。
+
+共有ヘルパーは既存のDeepSeekプロバイダーと同じエラー伝播を行い、新しい再試行や
+独自フォールバックは追加しない。
+
+## テスト
+
+Vitestで `@ai-sdk/deepseek` のプロバイダー生成関数を置き換え、
+`createSchedulingModel` が受け取ったAPIキーをそのまま渡すことと、生成した
+プロバイダーを正確に `deepseek-v4-flash` で呼ぶことを検証する。
+
+実装はテストを先に追加して期待どおり失敗することを確認し、その後に最小実装を
+追加する。完了時は全Vitest、TypeScript型検査、ESLint、本番ビルドを実行する。
+
+## 完了条件
+
+- 予約機能の2つのLLM利用箇所が共有ヘルパーを使用する。
+- 実行時に選択されるモデルIDが `deepseek-v4-flash` である。
+- `deepseek-chat` の予約機能内の参照が残っていない。
+- 既存のフォールバックとAPIエラー処理が維持される。
+- 回帰テスト、全テスト、型検査、lint、本番ビルドが成功する。

--- a/src/lib/scheduling-model.test.ts
+++ b/src/lib/scheduling-model.test.ts
@@ -44,6 +44,7 @@ describe("scheduling model", () => {
     const source = fs.readFileSync(path.join(ROOT, file), "utf8");
 
     expect(source).toContain("createSchedulingModel");
+    expect(source).not.toContain("createDeepSeek");
     expect(source).not.toContain("deepseek-chat");
   });
 });

--- a/src/lib/scheduling-model.test.ts
+++ b/src/lib/scheduling-model.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createDeepSeekMock, providerMock } = vi.hoisted(() => ({
+  createDeepSeekMock: vi.fn(),
+  providerMock: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/deepseek", () => ({
+  createDeepSeek: createDeepSeekMock,
+}));
+
+import {
+  createSchedulingModel,
+  SCHEDULING_MODEL_ID,
+} from "./scheduling-model";
+
+const ROOT = path.resolve(__dirname, "../..");
+const consumers = [
+  "src/lib/scheduling.ts",
+  "src/mastra/agents/scheduling-agent.ts",
+];
+
+describe("scheduling model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDeepSeekMock.mockReturnValue(providerMock);
+  });
+
+  it("creates the DeepSeek V4 Flash model with the provided API key", () => {
+    const expectedModel = { id: "test-model" };
+    providerMock.mockReturnValue(expectedModel);
+
+    const model = createSchedulingModel("test-api-key");
+
+    expect(SCHEDULING_MODEL_ID).toBe("deepseek-v4-flash");
+    expect(createDeepSeekMock).toHaveBeenCalledWith({ apiKey: "test-api-key" });
+    expect(providerMock).toHaveBeenCalledWith("deepseek-v4-flash");
+    expect(model).toBe(expectedModel);
+  });
+
+  it.each(consumers)("wires %s through the shared model factory", (file) => {
+    const source = fs.readFileSync(path.join(ROOT, file), "utf8");
+
+    expect(source).toContain("createSchedulingModel");
+    expect(source).not.toContain("deepseek-chat");
+  });
+});

--- a/src/lib/scheduling-model.ts
+++ b/src/lib/scheduling-model.ts
@@ -1,0 +1,8 @@
+import { createDeepSeek } from "@ai-sdk/deepseek";
+
+export const SCHEDULING_MODEL_ID = "deepseek-v4-flash";
+
+export function createSchedulingModel(apiKey: string | undefined) {
+  const deepseek = createDeepSeek({ apiKey });
+  return deepseek(SCHEDULING_MODEL_ID);
+}

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -1,7 +1,7 @@
-import { createDeepSeek } from "@ai-sdk/deepseek";
 import { generateText, Output } from "ai";
 import { z } from "zod";
 import { fetchBusy, fetchCalendarEventContexts, insertEvent } from "@/lib/google-calendar";
+import { createSchedulingModel } from "@/lib/scheduling-model";
 import type {
   AvailabilityResponse,
   BookingRequest,
@@ -223,9 +223,8 @@ async function classifyTravelPadding(
   if (!process.env.DEEPSEEK_API_KEY) return fallbackTravelDecisions(events);
 
   try {
-    const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
     const { output } = await generateText({
-      model: deepseek("deepseek-chat"),
+      model: createSchedulingModel(process.env.DEEPSEEK_API_KEY),
       temperature: 0,
       output: Output.object({ schema: travelPaddingDecisionSchema }),
       system: TRAVEL_PADDING_SYSTEM_PROMPT,

--- a/src/mastra/agents/scheduling-agent.ts
+++ b/src/mastra/agents/scheduling-agent.ts
@@ -1,12 +1,12 @@
 import { Agent } from "@mastra/core/agent";
-import { createDeepSeek } from "@ai-sdk/deepseek";
 import { DEFAULT_CONFIG, ownerToday } from "@/lib/scheduling";
+import { createSchedulingModel } from "@/lib/scheduling-model";
 import { findSlotsTool, bookSlotTool } from "../tools/scheduling-tools";
 
-const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
+const schedulingModel = createSchedulingModel(process.env.DEEPSEEK_API_KEY);
 
 /**
- * 日程調整エージェント。DeepSeek(`deepseek-chat`, 高速・非推論)。
+ * 日程調整エージェント。DeepSeek(`deepseek-v4-flash`, 高速・非推論)。
  * 役割: 訪問者の自然文を解釈 → find-slots で空きを提示 → 同意で book-slot で予約。
  * エージェントに渡すのは移動パディング適用後の空き枠と unavailable 時間帯のみ。
  * 予定名・場所・説明・参加者は渡さない。
@@ -58,6 +58,6 @@ export const schedulingAgent = new Agent({
   id: "scheduling",
   name: "Scheduling Agent",
   instructions: buildInstructions,
-  model: deepseek("deepseek-chat"),
+  model: schedulingModel,
   tools: { findSlotsTool, bookSlotTool },
 });


### PR DESCRIPTION
## 概要

- 予約機能のDeepSeekモデルを `deepseek-v4-flash` へ変更
- 予約会話エージェントと移動要否判定のモデル生成を共有ファクトリへ集約
- 2つの利用箇所が直接DeepSeekプロバイダーを生成しないことを回帰テストで保証

## 変更内容

- `SCHEDULING_MODEL_ID` と `createSchedulingModel` を追加
- 予約会話エージェントを共有モデルへ移行
- 移動要否判定を共有モデルへ移行
- APIキー未設定時と上流エラー時の既存フォールバックを維持

## 検証

- `npm run test`（15ファイル、188テスト成功）
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- タスク単位レビュー、全ブランチレビューともに指摘なし

## 補足

ローカル環境に `DEEPSEEK_API_KEY` が設定されていないため、実APIへの疎通確認は実施していません。

Related to #91
