### PR TITLE
予約モデルをDeepSeek V4 Flashへ変更

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -225,7 +225,7 @@ async function classifyTravelPadding(
   try {
     const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
     const { output } = await generateText({
-      model: deepseek("deepseek-chat"),
+      model: deepseek("deepseek-v4-flash"),
       temperature: 0,
       output: Output.object({ schema: travelPaddingDecisionSchema }),
       system: TRAVEL_PADDING_SYSTEM_PROMPT,

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -226,6 +226,7 @@ async function classifyTravelPadding(
     const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
     const { output } = await generateText({
       model: deepseek("deepseek-v4-flash"),
+      providerOptions: { deepseek: { thinking: { type: "disabled" } } },
       temperature: 0,
       output: Output.object({ schema: travelPaddingDecisionSchema }),
       system: TRAVEL_PADDING_SYSTEM_PROMPT,

--- a/src/mastra/agents/scheduling-agent.ts
+++ b/src/mastra/agents/scheduling-agent.ts
@@ -6,7 +6,7 @@ import { findSlotsTool, bookSlotTool } from "../tools/scheduling-tools";
 const deepseek = createDeepSeek({ apiKey: process.env.DEEPSEEK_API_KEY });
 
 /**
- * 日程調整エージェント。DeepSeek(`deepseek-chat`, 高速・非推論)。
+ * 日程調整エージェント。DeepSeek(`deepseek-v4-flash`, 高速・非推論)。
  * 役割: 訪問者の自然文を解釈 → find-slots で空きを提示 → 同意で book-slot で予約。
  * エージェントに渡すのは移動パディング適用後の空き枠と unavailable 時間帯のみ。
  * 予定名・場所・説明・参加者は渡さない。
@@ -58,6 +58,6 @@ export const schedulingAgent = new Agent({
   id: "scheduling",
   name: "Scheduling Agent",
   instructions: buildInstructions,
-  model: deepseek("deepseek-chat"),
+  model: deepseek("deepseek-v4-flash"),
   tools: { findSlotsTool, bookSlotTool },
 });

--- a/src/mastra/agents/scheduling-agent.ts
+++ b/src/mastra/agents/scheduling-agent.ts
@@ -59,5 +59,8 @@ export const schedulingAgent = new Agent({
   name: "Scheduling Agent",
   instructions: buildInstructions,
   model: deepseek("deepseek-v4-flash"),
+  defaultOptions: {
+    providerOptions: { deepseek: { thinking: { type: "disabled" } } },
+  },
   tools: { findSlotsTool, bookSlotTool },
 });


### PR DESCRIPTION
## 変更

- 予約エージェントのモデル名を `deepseek-v4-flash` に変更
- 移動要否判定のモデル名を `deepseek-v4-flash` に変更
- 両方の呼び出しで非思考モードを明示

上記以外のロジック、UI、テストには変更を加えていません。

## 検証

- `npm test`（14 files / 185 tests）
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
